### PR TITLE
Use "vmid" (lowercase) instead of "vmId" (camelCase)

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
@@ -559,7 +559,7 @@ Exception::Exception(const char *message)
 
 Entitlement::Entitlement(const std::string& response)
     : m_id(ExtractValue(response, "id"))
-    , m_vmId(ExtractValue(response, "vmId"))
+    , m_vmid(ExtractValue(response, "vmid"))
 {
 }
 
@@ -574,7 +574,7 @@ const std::string& Entitlement::Id() const
 
 const std::string& Entitlement::VmId() const
 {
-    return m_vmId;
+    return m_vmid;
 }
 
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.h
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.h
@@ -34,7 +34,7 @@ class Entitlement
 {
 private:
     std::string m_id;
-    std::string m_vmId;
+    std::string m_vmid;
 
 public:
     Entitlement(const std::string& response);

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <remarks>
         /// This may be verified by the calling software package as an (optional) additional check.
         /// </remarks>
-        [JsonProperty(PropertyName = "vmId")]
+        [JsonProperty(PropertyName = "vmid")]
         public string VirtualMachineId { get; set; }
     }
 }

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// Generation mode - create a new token for testing
         /// </summary>
         /// <param name="commandLine">Options from the command line.</param>
-        /// 
         /// <returns>Exit code to return from this process.</returns>
         public static int Generate(GenerateCommandLine commandLine)
         {


### PR DESCRIPTION
The JSON return from **sestest server** was incorrectly capitalised; corrected to be consistent with both the documentation and the production implementation.