### PR TITLE
Allow control of token audience

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -14,6 +14,8 @@ Critical (but small) fixes to the SDK.
 
 * **Fix**: The response from `sestest server` for a successful entitlement should use `vmid` to pass the identifier for the entitled virtual machine.
 
+* **Fix**: Required query parameter `odata=minimalmetadata` now supplied.
+
 ## May 2017
 
 Initial public release of the Software Entitlement Service SDK for Azure Batch, including:

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -203,7 +203,7 @@ If using a self-signed certificate, secure connection validation code in the nat
 libcurl_error 60: SSL certificate problem: unable to get local issuer certificate
 ```
 
-To turn off these checks, modify the source code in `SoftwareEntitlementClient.cpp`, around line #335:
+To turn off these checks, modify the source code in `SoftwareEntitlementClient.cpp`, around line #415:
 
 ``` cplusplus
 // During testing, if the certificate chain leaves something to be

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
                     Message = new ErrorMessage($"Entitlement for {entitlementRequest.ApplicationId} was denied.")
                 };
 
-                return StatusCode(403, error);
+                return StatusCode(400, error);
             }
 
             _logger.LogInformation(

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
             if (!IsValidApiVersion(apiVersion))
             {
                 _logger.LogError(
-                    "Selected api-version of {apiversion} is not supported; denying entitlement request.",
+                    "Selected api-version of {ApiVersion} is not supported; denying entitlement request.",
                     apiVersion);
 
                 var error = new SoftwareEntitlementFailureResponse
@@ -69,16 +69,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
             }
 
             _logger.LogInformation(
-                "Selected api-version is {apiversion}",
+                "Selected api-version is {ApiVersion}",
                 apiVersion);
 
             _logger.LogInformation(
-                "Requesting entitlement for {application}",
+                "Requesting entitlement for {Application}",
                 entitlementRequest.ApplicationId);
-            _logger.LogDebug("Request token: {token}", entitlementRequest.Token);
+            _logger.LogDebug("Request token: {Token}", entitlementRequest.Token);
 
             var remoteAddress = HttpContext.Connection.RemoteIpAddress;
-            _logger.LogDebug("Remote Address: {address}", remoteAddress);
+            _logger.LogDebug("Remote Address: {Address}", remoteAddress);
 
             var verificationResult = _verifier.Verify(
                 entitlementRequest.Token,

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -52,13 +52,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
         public IActionResult RequestEntitlement(
             [FromBody] SoftwareEntitlementRequest entitlementRequest)
         {
-            _logger.LogInformation("Request entitlement for {application}", entitlementRequest.ApplicationId);
+            _logger.LogInformation(
+                "Request entitlement for {application}",
+                entitlementRequest.ApplicationId);
             _logger.LogDebug("Request token: {token}", entitlementRequest.Token);
 
             var remoteAddress = HttpContext.Connection.RemoteIpAddress;
             _logger.LogDebug("Remote Address: {address}", remoteAddress);
 
-            var verificationResult = _verifier.Verify(entitlementRequest.Token, entitlementRequest.ApplicationId, remoteAddress);
+            var verificationResult = _verifier.Verify(
+                entitlementRequest.Token,
+                _options.Audience,
+                entitlementRequest.ApplicationId,
+                remoteAddress);
             if (!verificationResult.HasValue)
             {
                 foreach (var e in verificationResult.Errors)
@@ -98,14 +104,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
             public SecurityKey EncryptionKey { get; }
 
             /// <summary>
+            /// Gets the audience to which tokens should be addressed
+            /// </summary>
+            public string Audience { get; }
+
+            /// <summary>
             /// Initializes a new instance of the <see cref="Options"/> class.
             /// </summary>
             /// <param name="signingKey">Key to use when checking token signatures.</param>
             /// <param name="encryptionKey">Key to use when decrypting tokens.</param>
-            public Options(SecurityKey signingKey, SecurityKey encryptionKey)
+            /// <param name="audience">Audience to which tokens should be addressed.</param>
+            public Options(SecurityKey signingKey, SecurityKey encryptionKey, string audience)
             {
                 SigningKey = signingKey;
                 EncryptionKey = encryptionKey;
+                Audience = audience;
             }
         }
     }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -50,8 +50,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
         [HttpPost]
         [Produces("application/json")]
         public IActionResult RequestEntitlement(
-            [FromBody] SoftwareEntitlementRequest entitlementRequest)
+            [FromBody] SoftwareEntitlementRequest entitlementRequest,
+            [FromQuery(Name = "api-version")] string apiVersion)
         {
+            _logger.LogInformation(
+                "Selected api-version is {apiversion}",
+                apiVersion);
+
             _logger.LogInformation(
                 "Request entitlement for {application}",
                 entitlementRequest.ApplicationId);

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -12,10 +12,10 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
-| Placeholder | Type   | Description                                                                       |
-| ----------- | ------ | --------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable.  |
-| version     | string | The API version of the request. <p/> Must be `2017-05-01.5.0` or `2017-06-01.5.1` |
+| Placeholder | Type   | Description                                                                                                                                                                                     |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
+| version     | string | The API version of the request. <p/> Must be `2017-05-01.5.0` or higher. <p/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
 
 The following shows a sample JSON payload for the request:
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -12,10 +12,10 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
-| Placeholder | Type   | Description                                                                      |
-| ----------- | ------ | -------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable. |
-| version     | string | The API version of the request. <p/> Must be `2017-05-01.5.0`.                   |
+| Placeholder | Type   | Description                                                                       |
+| ----------- | ------ | --------------------------------------------------------------------------------- |
+| endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable.  |
+| version     | string | The API version of the request. <p/> Must be `2017-05-01.5.0` or `2017-06-01.5.1` |
 
 The following shows a sample JSON payload for the request:
 
@@ -76,4 +76,4 @@ The service will return HTTP status 400 and the response body will be empty if:
 
 * The software entitlement token is missing, invalid, or corrupt;
 * The request is badly formed; or
-* The api-version specified on the URL is invalid
+* The `api-version` specified on the URL is invalid.

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -12,13 +12,14 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
-| Placeholder | Type   | Description                                                                     |
-| ----------- | ------ | ------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable |
-| version     | string | The API version of the request <br/> Must be `2017-05-01.5.0` or later.         |
+| Placeholder | Type   | Description                                                                      |
+| ----------- | ------ | -------------------------------------------------------------------------------- |
+| endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable. |
+| version     | string | The API version of the request. <p/> Must be `2017-05-01.5.0`.                   |
 
 The following shows a sample JSON payload for the request:
-```
+
+``` json
 {
     "token": "...",
     "applicationId": "contosoapp"
@@ -37,9 +38,10 @@ Specific unique application identifiers for each software package will be agreed
 If the token grants permission to the requested application, the service will return HTTP Status 200 and the response body will contain details of the entitlement.
 
 The following example shows a sample JSON response:
-```
+
+``` json
 {
-    "id": "24223578-1CE8-4168-91E0-126C2D5EAA0B",
+    "id": "entitlement-24223578-1CE8-4168-91E0-126C2D5EAA0B",
     "vmid": "..."
 }
 ```
@@ -54,7 +56,8 @@ The following example shows a sample JSON response:
 If the token does not grant permission to use the requested application, the service will return HTTP status 403 and the response body will contain extended error information.
 
 The following example shows a sample JSON response:
-```
+
+``` json
 {
     "code": "EntitlementDenied",
     "message":
@@ -64,10 +67,13 @@ The following example shows a sample JSON response:
     }
 }
 ```
+
 See [Batch status and error codes](https://docs.microsoft.com/rest/api/batchservice/batch-status-and-error-codes) for more information.
 
 ### RESPONSE 400 - BAD REQUEST
 
-If the token is missing, invalid, corrupt, or the request is otherwise badly formed, the service will return HTTP status 400 and the response body will be empty.
+The service will return HTTP status 400 and the response body will be empty if:
 
-
+* The software entitlement token is missing, invalid, or corrupt;
+* The request is badly formed; or
+* The api-version specified on the URL is invalid

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -10,12 +10,12 @@ Verifies that a provided software entitlement token grants permission to use a s
 | ------ | ------------------------------------------------------ |
 | POST   | {endpoint}/softwareEntitlements/?api-version={version} |
 
-Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-01-01.3.1`
+Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
 | Placeholder | Type   | Description                                                                     |
 | ----------- | ------ | ------------------------------------------------------------------------------- |
 | endpoint    | string | The Batch account url endpoint supplied by Azure Batch via environment variable |
-| version     | string | The API version of the request                                                  |
+| version     | string | The API version of the request <br/> Must be `2017-05-01.5.0` or later.         |
 
 The following shows a sample JSON payload for the request:
 ```

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Claims.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Claims.cs
@@ -11,9 +11,11 @@
         public const string Application = "app";
 
         /// <summary>
-        /// The audience for each software entitlement token (essentially we self sign)
+        /// The default audience for each software entitlement token (essentially we self sign)
         /// </summary>
-        public const string Audience = "https://batch.azure.com/software-entitlement";
+        /// <remarks>In production, the audience for each token will be the batch account for whom 
+        /// it is issued.</remarks>
+        public const string DefaultAudience = "https://batch.azure.test/software-entitlement";
 
         /// <summary>
         /// The identifier to use for the actual entitlement id

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         public string Identifier { get; }
 
         /// <summary>
+        /// The audience for whom this entitlement is intended
+        /// </summary>
+        public string Audience { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="NodeEntitlements"/> class
         /// </summary>
         public NodeEntitlements()
@@ -57,6 +62,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             NotAfter = now + TimeSpan.FromDays(7);
             Applications = ImmutableHashSet<string>.Empty;
             IpAddresses = ImmutableHashSet<IPAddress>.Empty;
+            Audience = Claims.DefaultAudience;
         }
 
         /// <summary>
@@ -140,6 +146,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         }
 
         /// <summary>
+        /// Specify the audience to use in the token 
+        /// </summary>
+        /// <param name="audience">The audience for the generated token.</param>
+        /// <returns>A new entitlement</returns>
+        public NodeEntitlements WithAudience(string audience)
+        {
+            if (string.IsNullOrEmpty(audience))
+            {
+                throw new ArgumentException("Expect to have an audience", nameof(audience));
+            }
+
+            return new NodeEntitlements(this, audience: audience);
+        }
+
+        /// <summary>
         /// Cloning constructor to initialize a new instance of the <see cref="NodeEntitlements"/>
         /// class as a (near) copy of an existing one.
         /// </summary>
@@ -151,6 +172,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <param name="applications">The set of applications entitled to run.</param>
         /// <param name="identifier">Identifier to use for this entitlement.</param>
         /// <param name="addresses">Addresses of the entitled machine.</param>
+        /// <param name="audience">Audience for whom the token is intended.</param>
         private NodeEntitlements(
             NodeEntitlements original,
             DateTimeOffset? notBefore = null,
@@ -158,7 +180,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             string virtualMachineId = null,
             ImmutableHashSet<string> applications = null,
             string identifier = null,
-            ImmutableHashSet<IPAddress> addresses = null)
+            ImmutableHashSet<IPAddress> addresses = null,
+            string audience = null)
         {
             Created = original.Created;
 
@@ -168,6 +191,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Applications = applications ?? original.Applications;
             Identifier = identifier ?? original.Identifier;
             IpAddresses = addresses ?? original.IpAddresses;
+            Audience = audience ?? original.Audience;
         }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var claims = CreateClaims(entitlements);
 
             _logger.LogDebug(
-                "Not Before: {notBefore}",
+                "Not Before: {NotBefore}",
                 entitlements.NotBefore.ToString(TimestampParser.ExpectedFormat));
             _logger.LogDebug(
-                "Not After: {notAfter}",
+                "Not After: {NotAfter}",
                 entitlements.NotAfter.ToString(TimestampParser.ExpectedFormat));
 
             if (SigningCredentials != null)
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var handler = new JwtSecurityTokenHandler();
             var token = handler.CreateToken(securityTokenDescriptor);
 
-            _logger.LogDebug("Raw token: {token}", token);
+            _logger.LogDebug("Raw token: {Token}", token);
 
             return handler.WriteToken(token);
         }
@@ -105,25 +105,25 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             if (!string.IsNullOrEmpty(entitlements.VirtualMachineId))
             {
-                _logger.LogDebug("Virtual machine Id: {vmid}", entitlements.VirtualMachineId);
+                _logger.LogDebug("Virtual machine Id: {VirtualMachineId}", entitlements.VirtualMachineId);
                 claims.Add(new Claim(Claims.VirtualMachineId, entitlements.VirtualMachineId));
             }
 
             if (!string.IsNullOrEmpty(entitlements.Identifier))
             {
-                _logger.LogDebug("Entitlement Id: {identifier}", entitlements.Identifier);
+                _logger.LogDebug("Entitlement Id: {EntitlementId}", entitlements.Identifier);
                 claims.Add(new Claim(Claims.EntitlementId, entitlements.Identifier));
             }
 
             foreach (var ip in entitlements.IpAddresses)
             {
-                _logger.LogDebug("IP Address: {ip}", ip);
+                _logger.LogDebug("IP Address: {IP}", ip);
                 claims.Add(new Claim(Claims.IpAddress, ip.ToString()));
             }
 
             foreach (var app in entitlements.Applications)
             {
-                _logger.LogDebug("Application Id: {app}", app);
+                _logger.LogDebug("Application Id: {ApplicationId}", app);
                 var claim = new Claim(Claims.Application, app);
                 claims.Add(claim);
             }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 Expires = entitlements.NotAfter.UtcDateTime,
                 IssuedAt = DateTimeOffset.Now.UtcDateTime,
                 Issuer = Claims.Issuer,
-                Audience = Claims.Audience,
+                Audience = entitlements.Audience ?? Claims.DefaultAudience,
                 SigningCredentials = SigningCredentials,
                 EncryptingCredentials = EncryptingCredentials
             };

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenVerifier.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenVerifier.cs
@@ -73,16 +73,17 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// Verify the provided software entitlement token
         /// </summary>
         /// <param name="tokenString">A software entitlement token to verify.</param>
+        /// <param name="expectedAudience">The audience for whom the token should be intended.</param>
         /// <param name="application">The specific application id of the application </param>
         /// <param name="ipAddress">Address of the machine requesting token validation.</param>
         /// <returns>Either a software entitlement describing the approved entitlement, or errors
         /// explaining why it wasn't approved.</returns>
-        public Errorable<NodeEntitlements> Verify(string tokenString, string application, IPAddress ipAddress)
+        public Errorable<NodeEntitlements> Verify(string tokenString, string expectedAudience, string application, IPAddress ipAddress)
         {
             var validationParameters = new TokenValidationParameters
             {
                 ValidateAudience = true,
-                ValidAudience = Claims.Audience,
+                ValidAudience = expectedAudience,
                 ValidateIssuer = true,
                 ValidIssuer = Claims.Issuer,
                 ValidateLifetime = true,

--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -31,5 +31,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
         [Option('f', "token-file", HelpText = "The name of a file into which the token will be written (token will be written to the console otherwise).")]
         public string TokenFile { get; set; }
+
+        [Option("audience", HelpText = "Audience to which tokens will be addressed (optional; defaults to https://batch.azure.test/software-entitlement).")]
+        public string Audience { get; set; }
     }
 }

--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option('f', "token-file", HelpText = "The name of a file into which the token will be written (token will be written to the console otherwise).")]
         public string TokenFile { get; set; }
 
-        [Option("audience", HelpText = "Audience to which tokens will be addressed (optional; defaults to https://batch.azure.test/software-entitlement).")]
+        [Option("audience", HelpText = "Audience to which tokens will be addressed (optional; defaults to 'https://batch.azure.test/software-entitlement').")]
         public string Audience { get; set; }
     }
 }

--- a/src/sestest/NodeEntitlementsBuilder.cs
+++ b/src/sestest/NodeEntitlementsBuilder.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Configure(VirtualMachineId, url => entitlement.WithVirtualMachineId(url));
             Configure(NotBefore, notBefore => entitlement.FromInstant(notBefore));
             Configure(NotAfter, notAfter => entitlement.UntilInstant(notAfter));
+            Configure(Audience, audience => entitlement.WithAudience(audience));
             ConfigureAll(Addresses, address => entitlement.AddIpAddress(address));
             ConfigureAll(Applications, app => entitlement.AddApplication(app));
 
@@ -123,6 +124,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             return _timestampParser.TryParse(_commandLine.NotAfter, "NotAfter");
+        }
+
+        private Errorable<string> Audience()
+        {
+            if (string.IsNullOrEmpty(_commandLine.Audience))
+            {
+                return Errorable.Success(Claims.DefaultAudience);
+            }
+
+            return Errorable.Success(_commandLine.Audience);
         }
 
         private IEnumerable<Errorable<IPAddress>> Addresses()

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             var fileInfo = new FileInfo(commandLine.TokenFile);
-            _logger.LogInformation("Token file: {filename}", fileInfo.FullName);
+            _logger.LogInformation("Token file: {FileName}", fileInfo.FullName);
             try
             {
                 File.WriteAllText(fileInfo.FullName, token);
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var certificateStore = new CertificateStore();
             var allCertificates = certificateStore.FindAll();
             var withPrivateKey = allCertificates.Where(c => c.HasPrivateKey).ToList();
-            _logger.LogInformation("Found {count} certificates with private keys", withPrivateKey.Count);
+            _logger.LogInformation("Found {Count} certificates with private keys", withPrivateKey.Count);
 
             var rows = withPrivateKey.Select(DescribeCertificate).ToList();
             rows.Insert(0, new List<string> { "Name", "Friendly Name", "Thumbprint" });

--- a/src/sestest/ServerCommandLine.cs
+++ b/src/sestest/ServerCommandLine.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("connection", HelpText = "Thumbprint of the certificate to pin for use with HTTPS (mandatory).")]
         public string ConnectionCertificateThumbprint { get; set; }
 
-        [Option("url", HelpText = "The URL at which the server should process requests (defaults to https://localhost:4443; must start with 'https:').")]
+        [Option("url", HelpText = "The URL at which the server should process requests (defaults to 'https://localhost:4443'; must start with 'https:').")]
         public string ServerUrl { get; set; } = "https://localhost:4443";
 
-        [Option("audience", HelpText = "Audience to which all tokens must be addressed (optional; defaults to https://batch.azure.test/software-entitlement).")]
+        [Option("audience", HelpText = "Audience to which all tokens must be addressed (optional; defaults to 'https://batch.azure.test/software-entitlement').")]
         public string Audience { get; set; }
     }
 }

--- a/src/sestest/ServerCommandLine.cs
+++ b/src/sestest/ServerCommandLine.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("sign", HelpText = "Thumbprint of the certificate used to sign tokens (optional; if specified, all tokens must be signed).")]
         public string SigningCertificateThumbprint { get; set; }
 
-        //TODO: Document where this looks to find the certificate (in a cross platform way)
-        [Option("encrypt", HelpText = "Thumbprint of the certificate used to encrypt tokens (optional; if specified, all tokens must be encrypted.).")]
+        [Option("encrypt", HelpText = "Thumbprint of the certificate used to encrypt tokens (optional; if specified, all tokens must be encrypted).")]
         public string EncryptionCertificateThumbprint { get; set; }
 
         [Option("connection", HelpText = "Thumbprint of the certificate to pin for use with HTTPS (mandatory).")]
@@ -20,5 +19,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
         [Option("url", HelpText = "The URL at which the server should process requests (defaults to https://localhost:4443; must start with 'https:').")]
         public string ServerUrl { get; set; } = "https://localhost:4443";
+
+        [Option("audience", HelpText = "Audience to which all tokens must be addressed (optional; defaults to https://batch.azure.test/software-entitlement).")]
+        public string Audience { get; set; }
     }
 }

--- a/src/sestest/ServerOptionBuilder.cs
+++ b/src/sestest/ServerOptionBuilder.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Configure(ConnectionCertificate, cert => options.WithConnectionCertificate(cert));
             ConfigureOptional(SigningCertificate, cert => options.WithSigningCertificate(cert));
             ConfigureOptional(EncryptingCertificate, cert => options.WithEncryptionCertificate(cert));
+            ConfigureOptional(Audience, audience => options.WithAudience(audience));
 
             if (errors.Any())
             {
@@ -150,6 +151,20 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             return FindCertificate("encrypting", _commandLine.EncryptionCertificateThumbprint);
+        }
+
+        /// <summary>
+        /// Return the audience required 
+        /// </summary>
+        /// <returns>Error, if provided; error details otherwise.</returns>
+        private Errorable<string> Audience()
+        {
+            if (string.IsNullOrEmpty(_commandLine.Audience))
+            {
+                return Errorable.Success(Claims.DefaultAudience);
+            }
+
+            return Errorable.Success(_commandLine.Audience);
         }
 
         /// <summary>

--- a/src/sestest/ServerOptions.cs
+++ b/src/sestest/ServerOptions.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// </summary>
         public Uri ServerUrl { get; }
 
+        /// <summary> 
+        /// The token audience for which we will grant entitlements
+        /// </summary> 
+        public string Audience { get; }
+
         /// <summary>
         /// Initialize a blank set of server options
         /// </summary>
@@ -97,6 +102,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             return new ServerOptions(this, serverUrl: url);
         }
 
+        /// <summary> 
+        /// Specify the audience expected in the token  
+        /// </summary> 
+        /// <param name="audience">The audience expected within the generated token.</param> 
+        /// <returns>New instance of <see cref="ServerOptions"/>.</returns>
+        public ServerOptions WithAudience(string audience)
+        {
+            if (string.IsNullOrEmpty(audience))
+            {
+                throw new ArgumentException("Expect to have an audience", nameof(audience));
+            }
+
+            return new ServerOptions(this, audience: audience);
+        }
+
         /// <summary>
         /// Mutating constructor used to create variations of an existing set of options
         /// </summary>
@@ -105,12 +125,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <param name="encryptionCertificate">Certificate to use for encrypting tokens (optional).</param>
         /// <param name="connectionCertificate">Certificate to use for our HTTPS connection (optional).</param>
         /// <param name="serverUrl">Server host URL (optional).</param>
+        /// <param name="audience">Audience expected of tokens.</param>
         private ServerOptions(
             ServerOptions original,
             X509Certificate2 signingCertificate = null,
             X509Certificate2 encryptionCertificate = null,
             X509Certificate2 connectionCertificate = null,
-            Uri serverUrl = null)
+            Uri serverUrl = null,
+            string audience = null)
         {
             if (original == null)
             {
@@ -121,6 +143,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             EncryptionCertificate = encryptionCertificate ?? original.EncryptionCertificate;
             ConnectionCertificate = connectionCertificate ?? original.ConnectionCertificate;
             ServerUrl = serverUrl ?? original.ServerUrl;
+            Audience = audience ?? original.Audience;
         }
     }
 }

--- a/src/sestest/SoftwareEntitlementServer.cs
+++ b/src/sestest/SoftwareEntitlementServer.cs
@@ -62,7 +62,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             var signingKey = CreateX509SecurityKey(_options.SigningCertificate, "signing");
             var encryptingKey = CreateRsaSecurityKey(_options.EncryptionCertificate, "encryption");
-            var controllerOptions = new SoftwareEntitlementsController.Options(signingKey, encryptingKey);
+
+            _logger.LogDebug(
+                "Expected audience for all tokens {audience}",
+                _options.Audience);
+
+            var controllerOptions = new SoftwareEntitlementsController.Options(signingKey, encryptingKey, _options.Audience);
             services.AddSingleton(controllerOptions);
             services.AddSingleton(_logger);
             services.AddSingleton(_provider);

--- a/src/sestest/SoftwareEntitlementServer.cs
+++ b/src/sestest/SoftwareEntitlementServer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var encryptingKey = CreateRsaSecurityKey(_options.EncryptionCertificate, "encryption");
 
             _logger.LogDebug(
-                "Expected audience for all tokens {audience}",
+                "Expected audience for all tokens {Audience}",
                 _options.Audience);
 
             var controllerOptions = new SoftwareEntitlementsController.Options(signingKey, encryptingKey, _options.Audience);
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             if (certificate == null)
             {
-                _logger.LogDebug("No certificate specified for {purpose}", purpose);
+                _logger.LogDebug("No certificate specified for {Purpose}", purpose);
                 return null;
             }
 
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 return null;
             }
 
-            _logger.LogDebug("Creating security key for {purpose}", purpose);
+            _logger.LogDebug("Creating security key for {Purpose}", purpose);
             var parameters = certificate.GetRSAPrivateKey().ExportParameters(includePrivateParameters: true);
             return new RsaSecurityKey(parameters);
         }
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             if (certificate == null)
             {
-                _logger.LogDebug("No certificate specified for {purpose}", purpose);
+                _logger.LogDebug("No certificate specified for {Purpose}", purpose);
                 return null;
             }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 return null;
             }
 
-            _logger.LogDebug("Creating security key for {purpose}", purpose);
+            _logger.LogDebug("Creating security key for {Purpose}", purpose);
             return new X509SecurityKey(certificate);
         }
     }

--- a/src/sestest/readme.md
+++ b/src/sestest/readme.md
@@ -75,6 +75,7 @@ The `generate` mode allows you to generate a software entitlement token with the
 | --not-before  | Optional  | The moment at which the token becomes active and the application is entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to now.                |
 | --not-after   | Optional  | The moment at which the token expires and the application is no longer entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to 7 days from now. |
 | --address     | Optional  | The IP addresses of the machine entitled to execute the application(s). <br/> Defaults to all the IP addresses of the current machine.                                               |
+| --audience    | Optional  | Audience to the token will be addressed. <br/> Defaults to https://batch.azure.test/software-entitlement.                                                                            |
 | --sign        | Optional  | Thumbprint of the certificate to use for signing the token                                                                                                                           |
 | --encrypt     | Optional  | Thumbprint of the certificate to use for encryption of the token.                                                                                                                    |
 | --token-file  | Optional  | The name of a file into which the token will be written <br/> If not specified, the token will be shown in the log.                                                                  |

--- a/src/sestest/readme.md
+++ b/src/sestest/readme.md
@@ -31,7 +31,6 @@ You should observe the request for entitlement being processed by the window run
 | Token rejection   | Use `sestest generate` to create an **invalid** token (one that is not yet valid, one that is already expired, one for a different application, or one for a different computer) and supply it to your application. The diagnostic software entitlement server should **reject** the token and the application should act as non-entitled. |
 | Automated testing | Passing the `--exit-after-request` parameter to `sestest server` will cause the server to cleanly exit after processing one request; this enables an automated integration test with your application.                                                                                                   |
 
-
 ## Common parameters
 
 These parameters are available for every mode
@@ -49,7 +48,6 @@ These parameters are available for every mode
 Run `sestest server` to stand up a diagnostic software entitlement server, able to accept and verify tokens submitted by either the application. This allows full testing of the integration.
 
 **NOTE**: On Windows, ensure you run `sestest server` from an elevated shell window - this is required for certificate credential exchange to work. An error like _"The credentials supplied to the package were not recognized"_ may indicate that `sestest server` is running in a non-elevated shell window.
-
 
 | Parameter            | Required  | Definition                                                                                                                              |
 | -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -82,8 +80,9 @@ The `generate` mode allows you to generate a software entitlement token with the
 
 You can see this documentation for yourself by running `sestest generate --help` in your console.
 
-
 The exit code for `sestest generate` will be zero (**0**) if a token was correctly generated, non-zero (typically **-1**) if there were any issues.
+
+**PowerShell users**: If you want to list multiple values for the `--application` parameter, wrap the entire list in double quotes to avoid PowerShell interpreting the comma (`,`) for array construction: `--application "app, app, app"`.
 
 ## List certificates
 
@@ -102,4 +101,3 @@ Find a given certificate given a thumbprint and show some details of that certif
 | --thumbprint | Mandatory | Thumbprint of the certificate to find and display. |
 
 The exit code for `sestest find-certificate` will be zero (**0**) unless the application crashes.
-

--- a/src/sestest/readme.md
+++ b/src/sestest/readme.md
@@ -57,13 +57,14 @@ Run `sestest server` to stand up a diagnostic software entitlement server, able 
 | --url                | Optional  | The URL at which the server should process requests <br/> Defaults to `https://localhost:4443`; must start with `https:`.               |
 | --sign               | Optional  | Thumbprint of the certificate used to sign tokens. <br/> If specified, only tokens signed with this certificate will be approved.       |
 | --encrypt            | Optional  | Thumbprint of the certificate used to encrypt tokens. <br/> If specified, only tokens encrypted with this certificate will be approved. |
+| --audience           | Optional  | Audience to which all tokens must be addressed. <br/> Defaults to https://batch.azure.test/software-entitlement.                        |
 | --exit-after-request | Optional  | ***PLANNED*** The server will exit after processing a single request.                                                                   |
 
 You can see this documentation for yourself by running `sestest server --help` in your shell.
 
 The exit code for `sestest server` will be zero (**0**) for normal exit of the server, non-zero (typically **-1**) if there were any command line parameter issues, if the server could not start or if the server crashes.
 
-## Token generation 
+## Token generation
 
 The `generate` mode allows you to generate a software entitlement token with the details required for your test scenario.
 

--- a/src/sestest/readme.md
+++ b/src/sestest/readme.md
@@ -55,7 +55,7 @@ Run `sestest server` to stand up a diagnostic software entitlement server, able 
 | --url                | Optional  | The URL at which the server should process requests <br/> Defaults to `https://localhost:4443`; must start with `https:`.               |
 | --sign               | Optional  | Thumbprint of the certificate used to sign tokens. <br/> If specified, only tokens signed with this certificate will be approved.       |
 | --encrypt            | Optional  | Thumbprint of the certificate used to encrypt tokens. <br/> If specified, only tokens encrypted with this certificate will be approved. |
-| --audience           | Optional  | Audience to which all tokens must be addressed. <br/> Defaults to https://batch.azure.test/software-entitlement.                        |
+| --audience           | Optional  | Audience to which all tokens must be addressed. <br/> Defaults to `https://batch.azure.test/software-entitlement`.                      |
 | --exit-after-request | Optional  | ***PLANNED*** The server will exit after processing a single request.                                                                   |
 
 You can see this documentation for yourself by running `sestest server --help` in your shell.
@@ -73,7 +73,7 @@ The `generate` mode allows you to generate a software entitlement token with the
 | --not-before  | Optional  | The moment at which the token becomes active and the application is entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to now.                |
 | --not-after   | Optional  | The moment at which the token expires and the application is no longer entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to 7 days from now. |
 | --address     | Optional  | The IP addresses of the machine entitled to execute the application(s). <br/> Defaults to all the IP addresses of the current machine.                                               |
-| --audience    | Optional  | Audience to the token will be addressed. <br/> Defaults to https://batch.azure.test/software-entitlement.                                                                            |
+| --audience    | Optional  | Audience to the token will be addressed. <br/> Defaults to `https://batch.azure.test/software-entitlement`.                                                                          |
 | --sign        | Optional  | Thumbprint of the certificate to use for signing the token                                                                                                                           |
 | --encrypt     | Optional  | Thumbprint of the certificate to use for encryption of the token.                                                                                                                    |
 | --token-file  | Optional  | The name of a file into which the token will be written <br/> If not specified, the token will be shown in the log.                                                                  |

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         private readonly GenerateCommandLine _commandLine = new GenerateCommandLine
         {
             VirtualMachineId = "Sample",
-            Addresses = new List<string> {"127.0.0.1"},
-            ApplicationIds = new List<string> {"contosoapp"},
+            Addresses = new List<string> { "127.0.0.1" },
+            ApplicationIds = new List<string> { "contosoapp" },
             Audience = "https://account.region.batch.azure.test"
         };
 

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
@@ -14,8 +14,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         private readonly GenerateCommandLine _commandLine = new GenerateCommandLine
         {
             VirtualMachineId = "Sample",
-            Addresses = new List<string> { "127.0.0.1" },
-            ApplicationIds = new List<string> { "contosoapp" }
+            Addresses = new List<string> {"127.0.0.1"},
+            ApplicationIds = new List<string> {"contosoapp"},
+            Audience = "https://account.region.batch.azure.test"
         };
 
         public class BuildMethod : NodeEntitlementsBuilderTests
@@ -154,6 +155,27 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 // Compare as formatted strings to avoid issues with extra seconds we don't care about
                 entitlement.Value.NotAfter.ToString(TimestampParser.ExpectedFormat)
                     .Should().Be(_validNotAfter);
+            }
+        }
+
+        public class AudienceProperty : NodeEntitlementsBuilderTests
+        {
+            private readonly string _audience = "https://account.region.batch.azure.test";
+
+            [Fact]
+            public void WhenMissing_BuildReturnsValue()
+            {
+                _commandLine.Audience = string.Empty;
+                var result = NodeEntitlementsBuilder.Build(_commandLine);
+                result.HasValue.Should().BeTrue();
+            }
+
+            [Fact]
+            public void WhenValid_PropertyIsSet()
+            {
+                _commandLine.Audience = _audience;
+                var result = NodeEntitlementsBuilder.Build(_commandLine);
+                result.Value.Audience.Should().Be(_audience);
             }
         }
 

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsTests.cs
@@ -174,5 +174,36 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 entitlement.Identifier.Should().Be(_identifier);
             }
         }
+
+        public class WithAudienceMethod : NodeEntitlementsTests
+        {
+            // An audience to use
+            private readonly string _audience = "http://batch.test.example.com/account";
+
+            [Fact]
+            public void GivenNull_ThrowsException()
+            {
+                var exception =
+                    Assert.Throws<ArgumentException>(
+                        () => _emptyEntitlement.WithAudience(null));
+                exception.ParamName.Should().Be("audience");
+            }
+
+            [Fact]
+            public void GivenBlank_ThrowsException()
+            {
+                var exception =
+                    Assert.Throws<ArgumentException>(
+                        () => _emptyEntitlement.WithAudience(string.Empty));
+                exception.ParamName.Should().Be("audience");
+            }
+
+            [Fact]
+            public void GivenIpAddress_ModifiesConfiguration()
+            {
+                var entitlement = _emptyEntitlement.WithAudience(_audience);
+                entitlement.Audience.Should().Be(_audience);
+            }
+        }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             }
 
             [Fact]
-            public void GivenIpAddress_ModifiesConfiguration()
+            public void GivenAudience_ModifiesConfiguration()
             {
                 var entitlement = _emptyEntitlement.WithAudience(_audience);
                 entitlement.Audience.Should().Be(_audience);

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -3,6 +3,10 @@ using Xunit;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 {
+    /// <summary>
+    /// Negative tests to ensure the <see cref="ServerOptionBuilder"/> correctly reports error 
+    /// cases for each possible parameter
+    /// </summary>
     public class ServerOptionBuilderTests
     {
         // One thumbprint string to use for testing
@@ -64,6 +68,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             _commandLine.ConnectionCertificateThumbprint = _thumbprint;
             var options = ServerOptionBuilder.Build(_commandLine);
             options.Errors.Should().Contain(e => e.Contains("connection"));
+        }
+
+        [Fact]
+        public void Build_WithEmptyAudience_HasErrorForAudience()
+        {
+            _commandLine.Audience = string.Empty;
+            var options = ServerOptionBuilder.Build(_commandLine);
+            options.Errors.Should().Contain(e => e.Contains("audience"));
         }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         }
 
         [Fact]
-        public void Build_WithEmptyAudience_HasErrorForAudience()
+        public void Build_WithEmptyAudience_HasDefaultValueForAudience()
         {
             _commandLine.Audience = string.Empty;
             var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().Contain(e => e.Contains("audience"));
+            options.Value.Audience.Should().NotBeNullOrEmpty();
         }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 
             public static IEnumerable<object[]> TestCaseKeys()
             {
-                // To use this test, change the next line by entering a thumb-print that exists on the test machine
+                // To use this test, change the next line by entering a thumbprint that exists on the test machine
                 var thumbprint = new CertificateThumbprint("<thumbprint-goes-here>");
                 var store = new CertificateStore();
                 var cert = store.FindByThumbprint("test", thumbprint);


### PR DESCRIPTION
New parameter `--audience`:
* for **generate** mode, allows specifying the audience of the generated token
* for **server** mode, to allow specifying the accepted audience

Also, **server** mode now logs the `api-version` requested to allow inspection