### PR TITLE
GetEntitlement: Take string by value rather than reference to allow c…

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
@@ -596,7 +596,7 @@ void Cleanup()
 // providing details of entitlement validation failure.
 //
 std::unique_ptr<Entitlement> GetEntitlement(
-    std::string& url,
+    std::string url,
     const std::string& entitlement_token,
     const std::string& requested_entitlement)
 {

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.h
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.h
@@ -52,7 +52,7 @@ public:
 // entitlement validation failure.
 //
 std::unique_ptr<Entitlement> GetEntitlement(
-    std::string& url,
+    std::string url,
     const std::string& entitlement_token,
     const std::string& requested_entitlement
 );


### PR DESCRIPTION
…allers to use const strings.