### PR TITLE
Run unit tests when building

### DIFF
--- a/build-xplat.ps1
+++ b/build-xplat.ps1
@@ -12,3 +12,8 @@ Write-Header "Restoring Nuget packages"
 Write-Header "Building SESTEST"
 & $dotnetExe build .\src\sestest
 
+Write-Header "Running Unit Tests"
+foreach ($project in (resolve-path .\tests\*\*.csproj))
+{
+    & $dotnetExe test $project
+}

--- a/src/sestest/ServerCommandLine.cs
+++ b/src/sestest/ServerCommandLine.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine;
+﻿using System;
+using CommandLine;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {

--- a/src/sestest/ServerOptionBuilder.cs
+++ b/src/sestest/ServerOptionBuilder.cs
@@ -18,16 +18,22 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         // Reference to a store in which we can search for certificates
         private readonly CertificateStore _certificateStore = new CertificateStore();
 
+        // Options used to configure validation
+        private readonly ServerOptionBuilderOptions _options;
+
         /// <summary>
         /// Build an instance of <see cref="ServerOptions"/> from the information supplied on the 
         /// command line by the user
         /// </summary>
         /// <param name="commandLine">Command line parameters supplied by the user.</param>
+        /// <param name="options">Options for configuring validation.</param>
         /// <returns>Either a usable (and completely valid) <see cref="ServerOptions"/> or a set 
         /// of errors.</returns>
-        public static Errorable<ServerOptions> Build(ServerCommandLine commandLine)
+        public static Errorable<ServerOptions> Build(
+            ServerCommandLine commandLine,
+            ServerOptionBuilderOptions options = ServerOptionBuilderOptions.None)
         {
-            var builder = new ServerOptionBuilder(commandLine);
+            var builder = new ServerOptionBuilder(commandLine, options);
             return builder.Build();
         }
 
@@ -35,9 +41,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// Initializes a new instance of the <see cref="ServerOptionBuilder"/> class
         /// </summary>
         /// <param name="commandLine">Options provided on the command line.</param>
-        private ServerOptionBuilder(ServerCommandLine commandLine)
+        /// <param name="options">Options for configuring validation.</param>
+        private ServerOptionBuilder(
+            ServerCommandLine commandLine,
+            ServerOptionBuilderOptions options)
         {
             _commandLine = commandLine;
+            _options = options;
         }
 
         /// <summary>
@@ -73,7 +83,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             Configure(ServerUrl, url => options.WithServerUrl(url));
-            Configure(ConnectionCertificate, cert => options.WithConnectionCertificate(cert));
+            ConfigureOptional(ConnectionCertificate, cert => options.WithConnectionCertificate(cert));
             ConfigureOptional(SigningCertificate, cert => options.WithSigningCertificate(cert));
             ConfigureOptional(EncryptingCertificate, cert => options.WithEncryptionCertificate(cert));
             ConfigureOptional(Audience, audience => options.WithAudience(audience));
@@ -95,6 +105,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             if (string.IsNullOrWhiteSpace(_commandLine.ServerUrl))
             {
+                if (_options.HasFlag(ServerOptionBuilderOptions.ServerUrlOptional))
+                {
+                    return Errorable.Success(new Uri("http://test"));
+                }
+
                 return Errorable.Failure<Uri>("No server endpoint URL specified.");
             }
 
@@ -120,6 +135,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Certificate, if found; error details otherwise.</returns>
         private Errorable<X509Certificate2> ConnectionCertificate()
         {
+            if (string.IsNullOrEmpty(_commandLine.ConnectionCertificateThumbprint))
+            {
+                if (_options.HasFlag(ServerOptionBuilderOptions.ConnectionThumbprintOptional))
+                {
+                    return Errorable.Success<X509Certificate2>(null);
+                }
+
+                return Errorable.Failure<X509Certificate2>("A connection thumbprint is required.");
+            }
+
             return FindCertificate("connection", _commandLine.ConnectionCertificateThumbprint);
         }
 
@@ -183,5 +208,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var certificateThumbprint = new CertificateThumbprint(thumbprint);
             return _certificateStore.FindByThumbprint(purpose, certificateThumbprint);
         }
+    }
+
+
+    [Flags]
+    public enum ServerOptionBuilderOptions
+    {
+        None,
+        ServerUrlOptional,
+        ConnectionThumbprintOptional
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 {
     /// <summary>
-    /// Negative tests to ensure the <see cref="ServerOptionBuilder"/> correctly reports error 
+    /// Tests to ensure the <see cref="ServerOptionBuilder"/> correctly reports error 
     /// cases for each possible parameter
     /// </summary>
     public class ServerOptionBuilderTests
@@ -15,67 +15,83 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         // Server options for testing
         private readonly ServerCommandLine _commandLine = new ServerCommandLine();
 
-        [Fact]
-        public void Build_WithEmptyServerUrl_DoesNotReturnValue()
+        // Permissive options to bypass mandatory errors when testing other properties
+        private readonly ServerOptionBuilderOptions _permissiveOptions =
+            ServerOptionBuilderOptions.ServerUrlOptional
+            | ServerOptionBuilderOptions.ConnectionThumbprintOptional;
+
+        public class ServerUrl : ServerOptionBuilderTests
         {
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.HasValue.Should().BeFalse();
+            [Fact]
+            public void Build_WithEmptyServerUrl_DoesNotReturnValue()
+            {
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.HasValue.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Build_WithEmptyServerUrl_HasErrorForServerUrl()
+            {
+                _commandLine.ServerUrl = string.Empty;
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.Errors.Should().Contain(e => e.Contains("server endpoint URL"));
+            }
+
+            [Fact]
+            public void Build_WithHttpServerUrl_HasErrorForServerUrl()
+            {
+                _commandLine.ServerUrl = "http://www.example.com";
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.Errors.Should().Contain(e => e.Contains("Server endpoint URL"));
+            }
+
+            [Fact]
+            public void WithValidServerUrl_ConfigureServerUrl()
+            {
+                _commandLine.ServerUrl = "https://example.com/";
+                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                options.Value.ServerUrl.ToString().Should().Be(_commandLine.ServerUrl);
+            }
         }
 
-        [Fact]
-        public void Build_WithEmptyServerUrl_HasErrorForServerUrl()
+        public class ConnectionThumbprint : ServerOptionBuilderTests
         {
-            _commandLine.ServerUrl = string.Empty;
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().Contain(e => e.Contains("server endpoint URL"));
+            [Fact]
+            public void Build_WithNoConnectionThumbprint_DoesNotReturnValue()
+            {
+                _commandLine.ConnectionCertificateThumbprint = string.Empty;
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.HasValue.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Build_WithNoConnectionThumbprint_HasErrorForConnection()
+            {
+                _commandLine.ConnectionCertificateThumbprint = string.Empty;
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.Errors.Should().Contain(e => e.Contains("connection"));
+            }
+
+            [Fact]
+            public void Build_WithUnknownConnectionThumbprint_HasErrorForConnection()
+            {
+                _commandLine.ConnectionCertificateThumbprint = _thumbprint;
+                var options = ServerOptionBuilder.Build(_commandLine);
+                options.Errors.Should().Contain(e => e.Contains("connection"));
+            }
         }
 
-        [Fact]
-        public void Build_WithValidServerUrl_HasNoErrorForServerUrl()
+        public class Audience : ServerOptionBuilderTests
         {
-            _commandLine.ServerUrl = "https://example.com";
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().NotContain(e => e.Contains("server endpoint URL"));
-        }
-
-        [Fact]
-        public void Build_WithHttpServerUrl_HasErrorForServerUrl()
-        {
-            _commandLine.ServerUrl = "http://www.example.com";
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().Contain(e => e.Contains("Server endpoint URL"));
-        }
-
-        [Fact]
-        public void Build_WithNoConnectionThumbprint_DoesNotReturnValue()
-        {
-            _commandLine.ConnectionCertificateThumbprint = string.Empty;
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.HasValue.Should().BeFalse();
-        }
-
-        [Fact]
-        public void Build_WithNoConnectionThumbprint_HasErrorForConnection()
-        {
-            _commandLine.ConnectionCertificateThumbprint = string.Empty;
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().Contain(e => e.Contains("connection"));
-        }
-
-        [Fact]
-        public void Build_WithUnknownConnectionThumbprint_HasErrorForConnection()
-        {
-            _commandLine.ConnectionCertificateThumbprint = _thumbprint;
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Errors.Should().Contain(e => e.Contains("connection"));
-        }
-
-        [Fact]
-        public void Build_WithEmptyAudience_HasDefaultValueForAudience()
-        {
-            _commandLine.Audience = string.Empty;
-            var options = ServerOptionBuilder.Build(_commandLine);
-            options.Value.Audience.Should().NotBeNullOrEmpty();
+            [Fact]
+            public void Build_WithEmptyAudience_HasDefaultValueForAudience()
+            {
+                _commandLine.Audience = string.Empty;
+                var options = ServerOptionBuilder.Build(
+                    _commandLine,
+                    ServerOptionBuilderOptions.ServerUrlOptional | ServerOptionBuilderOptions.ConnectionThumbprintOptional);
+                options.Value.Audience.Should().NotBeNullOrEmpty();
+            }
         }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 
         public class WithCertificates : TokenEnforcementTests
         {
-            [Theory(Skip = "Need a thumbprint specified in TestCaseKeys()")]
+            [Theory(Skip = "Specify a certificate thumbprint in TestCaseKeys() to enable this test.")]
             [MemberData(nameof(TestCaseKeys))]
             public void WhenSignedByCertificate_ReturnsExpectedResult(SecurityKey key)
             {
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 result.Value.Applications.Should().Contain(_contosoFinanceApp);
             }
 
-            [Theory(Skip = "Need a thumbprint specified in TestCaseKeys()")]
+            [Theory(Skip = "Specify a certificate thumbprint in TestCaseKeys() to enable this test.")]
             [MemberData(nameof(TestCaseKeys))]
             public void WhenEncryptedByCertificate_ReturnsExpectedResult(SecurityKey key)
             {


### PR DESCRIPTION
* Ensure all unit tests are run when the build script is used
* Fix a test that was failing by refactoring `ServerOptionBuilder` so certain checks can be disabled when testing
* General tidy up of tests for `ServerOptionBuilder`
* Improve wording on tests skipped for lack of a certificate