### PR TITLE
Prefer finding certificates with private keys over ones without

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
@@ -89,8 +89,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             var certWithPrivateKey = candidates.Find(cert => cert.HasPrivateKey);
             if (certWithPrivateKey != null)
             {
-                // We might have multiple copies of the certificate available
+                // We might have multiple copies of the same certificate available in different stores.
                 // If so, prefer any copies that have their private key over those that do not
+                // Certificates with private keys can be used to both encrypt/decrypt and to 
+                // sign/verify - copies without can only be used to encrypt and verify.
                 return Errorable.Success(certWithPrivateKey);
             }
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
@@ -84,13 +84,23 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
                 from location in _storeLocations
                 select FindByThumbprint(thumbprint, name, location);
 
-            var certificate = query.FirstOrDefault(cert => cert != null);
-            if (certificate == null)
+            var candidates = query.Where(cert => cert != null).ToList();
+
+            var certWithPrivateKey = candidates.Find(cert => cert.HasPrivateKey);
+            if (certWithPrivateKey != null)
             {
-                return Errorable.Failure<X509Certificate2>($"Did not find {purpose} certificate {thumbprint}");
+                // We might have multiple copies of the certificate available
+                // If so, prefer any copies that have their private key over those that do not
+                return Errorable.Success(certWithPrivateKey);
             }
 
-            return Errorable.Success(certificate);
+            var certificate = candidates.FirstOrDefault();
+            if (certificate != null)
+            {
+                return Errorable.Success(certificate);
+            }
+
+            return Errorable.Failure<X509Certificate2>($"Did not find {purpose} certificate {thumbprint}");
         }
 
         /// <summary>


### PR DESCRIPTION
If a certificate is installed multiple times into different stores, the private key may only be available from some of them. Since all of our certificate use requires private keys, we want to prefer finding (and using) installations with private keys over those that don't have them.