### PR TITLE
Make the --thumbprint and --common-name parameters optional for sesclient

### DIFF
--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -78,17 +78,17 @@ public:
         return false;
     }
 
-    bool contains(std::string name)
+    bool contains(const std::string& name) const
     {
         return _parameters.find(name) != _parameters.end();
     }
 
-    std::string find(std::string name)
+    std::string find(const std::string& name) const
     {
         return _parameters.find(name)->second;
     }
 
-    bool hasConfigurationError()
+    bool hasConfigurationError() const
     {
         return _hasConfigurationError;
     }
@@ -127,8 +127,7 @@ private:
     }
 };
 
-
-bool configureConnection(ParameterParser& parameters)
+bool configureConnection(const ParameterParser& parameters)
 {
     if (!parameters.contains("--thumbprint")
         && !parameters.contains("--common-name"))

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -161,7 +161,10 @@ std::string readToken(ParameterParser& parameters)
     if (token == "-")
     {
         // Read the token from stdin.
-        std::getline(std::cin, token);
+        if (!std::getline(std::cin, token))
+        {
+            throw std::runtime_error("Failed to read token from stdin");
+        }
     }
 
     return token;

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -77,6 +77,18 @@ std::unordered_map<std::string, std::string> ReadParameters(int argc, char** arg
 	return parameters;
 }
 
+std::string ReadToken(const std::unordered_map<std::string, std::string>& parameters)
+{
+	std::string token = parameters.find("--token")->second;
+	if (token == "-")
+	{
+		// Read the token from stdin.
+		std::getline(std::cin, token);
+	}
+
+	return token;
+}
+
 int main(int argc, char** argv)
 {
     try
@@ -84,15 +96,7 @@ int main(int argc, char** argv)
         Initializer init;
 
 		auto parameters = ReadParameters(argc, argv);
-
-        std::string token = parameters.find("--token")->second;
-        if (token == "-")
-        {
-            //
-            // Read the token from stdin.
-            //
-            std::getline(std::cin, token);
-        }
+		auto token = ReadToken(parameters);
 
         Microsoft::Azure::Batch::SoftwareEntitlement::AddSslCertificate(
             parameters.find("--thumbprint")->second,

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -18,13 +18,13 @@ void ShowUsage(const char* exeName)
 }
 
 
-static const std::vector<std::string> mandatoryParameterNames = {
+static const std::array<std::string, 3> mandatoryParameterNames = {
     "--url",
     "--token",
     "--application"
 };
 
-static const std::vector<std::string> optionalParameterNames = {
+static const std::array<std::string, 2> optionalParameterNames = {
     "--thumbprint",
     "--common-name"
 };

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -14,10 +14,15 @@ void ShowUsage(const char* exeName)
 }
 
 
-static const std::array<std::string, 3> mandatoryParameterNames = {
+static const std::vector<std::string> mandatoryParameterNames = {
 	"--url",
 	"--token",
 	"--application"
+};
+
+static const std::vector<std::string> optionalParameterNames = {
+	"--thumbprint",
+	"--common-name"
 };
 
 struct Initializer
@@ -43,6 +48,35 @@ struct Initializer
 auto shouldShowUsage = false;
 auto configurationError = false;
 
+void CheckForMandatoryParameters(const std::unordered_map<std::string, std::string>& parameters)
+{
+	for (const auto& param : mandatoryParameterNames)
+	{
+		if (parameters.find(param) == parameters.end())
+		{
+			std::cout << "Missing mandatory parameter " << param << std::endl;
+			configurationError = true;
+		}
+	}
+}
+
+void CheckForExtraParameters(const std::unordered_map<std::string, std::string>& parameters)
+{
+	for (const auto& parameter : parameters)
+	{
+		if (std::find(mandatoryParameterNames.begin(), mandatoryParameterNames.end(), parameter.first) != mandatoryParameterNames.end()) {
+			continue;
+		}
+
+		if (std::find(optionalParameterNames.begin(), optionalParameterNames.end(), parameter.first) != optionalParameterNames.end()) {
+			continue;
+		}
+
+		std::cout << "Unexpected additional parameter " << parameter.second << std::endl;
+		configurationError = true;
+	}
+}
+
 std::unordered_map<std::string, std::string> ReadParameters(int argc, char** argv)
 {
 	std::unordered_map<std::string, std::string> parameters;
@@ -64,14 +98,8 @@ std::unordered_map<std::string, std::string> ReadParameters(int argc, char** arg
 	}
 	else
 	{
-		for (const auto& param : mandatoryParameterNames)
-		{
-			if (parameters.find(param) == parameters.end())
-			{
-				std::cout << "Missing mandatory parameter " << param << std::endl;
-				configurationError = true;
-			}
-		}
+		CheckForMandatoryParameters(parameters);
+		CheckForExtraParameters(parameters);
 	}
 
 	return parameters;

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -14,14 +14,11 @@ void ShowUsage(const char* exeName)
 }
 
 
-static const std::array<std::string, 5> parameterNames = {
+static const std::array<std::string, 3> mandatoryParameterNames = {
     "--url",
-    "--thumbprint",
-    "--common-name",
     "--token",
     "--application"
 };
-
 
 struct Initializer
 {
@@ -64,7 +61,7 @@ int main(int argc, char** argv)
             parameters.emplace(key, value);
         }
 
-        for (const auto& param : parameterNames)
+        for (const auto& param : mandatoryParameterNames)
         {
             if (parameters.find(param) == parameters.end())
             {

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -53,7 +53,7 @@ struct ParameterParser
 {
 public:
 
-    void parse(int argc, char** argv)
+    bool parse(int argc, char** argv)
     {
         if ((argc % 2) == 1)
         {
@@ -68,13 +68,14 @@ public:
 
         if (_parameters.size() == 0)
         {
-            _shouldShowUsage = true;
+            // Need to show usage to the end user
+            return true;
         }
-        else
-        {
-            checkForMandatoryParameters(_parameters);
-            checkForExtraParameters(_parameters);
-        }
+
+        checkForMandatoryParameters(_parameters);
+        checkForExtraParameters(_parameters);
+
+        return false;
     }
 
     bool contains(std::string name)
@@ -87,18 +88,12 @@ public:
         return _parameters.find(name)->second;
     }
 
-    bool shouldShowUsage()
-    {
-        return _shouldShowUsage;
-    }
-
     bool hasConfigurationError()
     {
         return _hasConfigurationError;
     }
 
 private:
-    bool _shouldShowUsage = false;
     bool _hasConfigurationError = false;
     std::unordered_map<std::string, std::string> _parameters;
 
@@ -180,9 +175,8 @@ int main(int argc, char** argv)
         Initializer init;
         ParameterParser parser;
 
-        parser.parse(argc, argv);
-
-        if (parser.shouldShowUsage())
+        auto shouldShowUsage = parser.parse(argc, argv);
+        if (shouldShowUsage)
         {
             ShowUsage(argv[0]);
             return -1;

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -77,6 +77,33 @@ std::unordered_map<std::string, std::string> ReadParameters(int argc, char** arg
 	return parameters;
 }
 
+void ConfigureConnection(const std::unordered_map<std::string, std::string>& parameters)
+{
+	auto thumbprintParameter = parameters.find("--thumbprint");
+	auto commonNameParameter = parameters.find("--common-name");
+
+	if (thumbprintParameter != parameters.end()
+		&& commonNameParameter != parameters.end())
+	{
+		Microsoft::Azure::Batch::SoftwareEntitlement::AddSslCertificate(
+			thumbprintParameter->second,
+			commonNameParameter->second
+		);
+	}
+	else if (thumbprintParameter == parameters.end()
+		&& commonNameParameter != parameters.end())
+	{
+		std::cout << "--thumbprint must be used when --common-name is used" << std::endl;
+		configurationError = true;
+	}
+	else if (thumbprintParameter != parameters.end()
+		&& commonNameParameter == parameters.end())
+	{
+		std::cout << "--common-name must be used when --thumbprint is used" << std::endl;
+		configurationError = true;
+	}
+}
+
 std::string ReadToken(const std::unordered_map<std::string, std::string>& parameters)
 {
 	std::string token = parameters.find("--token")->second;
@@ -97,11 +124,7 @@ int main(int argc, char** argv)
 
 		auto parameters = ReadParameters(argc, argv);
 		auto token = ReadToken(parameters);
-
-        Microsoft::Azure::Batch::SoftwareEntitlement::AddSslCertificate(
-            parameters.find("--thumbprint")->second,
-            parameters.find("--common-name")->second
-        );
+		ConfigureConnection(parameters);
 
 		if (shouldShowUsage)
 		{

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -3,14 +3,18 @@
 
 void ShowUsage(const char* exeName)
 {
-	std::cout << exeName << ":" << std::endl;
-	std::cout << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl;
-	std::cout << "Parameters:" << std::endl;
-	std::cout << "    --url <software entitlement server URL>" << std::endl;
-	std::cout << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain (optional)>" << std::endl;
-	std::cout << "    --common-name <common name of the certificate with the specified thumbprint (optional)>" << std::endl;
-	std::cout << "    --token <software entitlement token to pass to the server>" << std::endl;
-	std::cout << "    --application <name of the license ID being requested>" << std::endl;
+    std::cout
+        << exeName << ":" << std::endl
+        << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl
+        << std::endl
+        << "Mandatory parameters:" << std::endl
+        << "    --url <software entitlement server URL>" << std::endl
+        << "    --token <software entitlement token to pass to the server>" << std::endl
+        << "    --application <name of the license ID being requested>" << std::endl
+        << std::endl
+        << "Mandatory parameters:" << std::endl
+        << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain>" << std::endl
+        << "    --common-name <common name of the certificate with the specified thumbprint>" << std::endl;
 }
 
 

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -3,7 +3,7 @@
 
 void ShowUsage(const char* exeName)
 {
-    std::cout
+    std::cerr
         << exeName << ":" << std::endl
         << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl
         << std::endl

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -1,173 +1,174 @@
 #include "stdafx.h"
 
-
-void ShowUsage(const char* exeName)
+namespace
 {
-    std::cerr
-        << exeName << ":" << std::endl
-        << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl
-        << std::endl
-        << "Mandatory parameters:" << std::endl
-        << "    --url <software entitlement server URL>" << std::endl
-        << "    --token <software entitlement token to pass to the server>" << std::endl
-        << "    --application <name of the license ID being requested>" << std::endl
-        << std::endl
-        << "Mandatory parameters:" << std::endl
-        << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain>" << std::endl
-        << "    --common-name <common name of the certificate with the specified thumbprint>" << std::endl;
-}
-
-
-static const std::array<std::string, 3> mandatoryParameterNames = {
-    "--url",
-    "--token",
-    "--application"
-};
-
-static const std::array<std::string, 2> optionalParameterNames = {
-    "--thumbprint",
-    "--common-name"
-};
-
-struct Initializer
-{
-    Initializer()
+    void ShowUsage(const char* exeName)
     {
-        int err = Microsoft::Azure::Batch::SoftwareEntitlement::Init();
-        if (err != 0)
-        {
-            throw std::runtime_error(
-                "Microsoft::Azure::Batch::SoftwareEntitlement::Init failed with error " +
-                std::to_string(err)
-            );
-        }
+        std::cerr
+            << exeName << ":" << std::endl
+            << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl
+            << std::endl
+            << "Mandatory parameters:" << std::endl
+            << "    --url <software entitlement server URL>" << std::endl
+            << "    --token <software entitlement token to pass to the server>" << std::endl
+            << "    --application <name of the license ID being requested>" << std::endl
+            << std::endl
+            << "Mandatory parameters:" << std::endl
+            << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain>" << std::endl
+            << "    --common-name <common name of the certificate with the specified thumbprint>" << std::endl;
     }
 
-    ~Initializer()
-    {
-        Microsoft::Azure::Batch::SoftwareEntitlement::Cleanup();
-    }
-};
+    static const std::array<std::string, 3> mandatoryParameterNames = {
+        "--url",
+        "--token",
+        "--application"
+    };
 
-struct ParameterParser
-{
-public:
+    static const std::array<std::string, 2> optionalParameterNames = {
+        "--thumbprint",
+        "--common-name"
+    };
 
-    bool parse(int argc, char** argv)
+    struct Initializer
     {
-        if ((argc % 2) == 1)
+        Initializer()
         {
-            // We have pairs of parameters, collect them into our map
-            while (argc != 1)
+            int err = Microsoft::Azure::Batch::SoftwareEntitlement::Init();
+            if (err != 0)
             {
-                auto value = argv[--argc];
-                auto key = argv[--argc];
-                _parameters.emplace(key, value);
+                throw std::runtime_error(
+                    "Microsoft::Azure::Batch::SoftwareEntitlement::Init failed with error " +
+                    std::to_string(err)
+                );
             }
         }
 
-        if (_parameters.size() == 0)
+        ~Initializer()
         {
-            // Need to show usage to the end user
-            return true;
+            Microsoft::Azure::Batch::SoftwareEntitlement::Cleanup();
+        }
+    };
+
+    struct ParameterParser
+    {
+    public:
+
+        bool parse(int argc, char** argv)
+        {
+            if ((argc % 2) == 1)
+            {
+                // We have pairs of parameters, collect them into our map
+                while (argc != 1)
+                {
+                    auto value = argv[--argc];
+                    auto key = argv[--argc];
+                    _parameters.emplace(key, value);
+                }
+            }
+
+            if (_parameters.size() == 0)
+            {
+                // Need to show usage to the end user
+                return true;
+            }
+
+            checkForMandatoryParameters(_parameters);
+            checkForExtraParameters(_parameters);
+
+            return false;
         }
 
-        checkForMandatoryParameters(_parameters);
-        checkForExtraParameters(_parameters);
-
-        return false;
-    }
-
-    bool contains(const std::string& name) const
-    {
-        return _parameters.find(name) != _parameters.end();
-    }
-
-    std::string find(const std::string& name) const
-    {
-        return _parameters.find(name)->second;
-    }
-
-    bool hasConfigurationError() const
-    {
-        return _hasConfigurationError;
-    }
-
-private:
-    bool _hasConfigurationError = false;
-    std::unordered_map<std::string, std::string> _parameters;
-
-    void checkForMandatoryParameters(const std::unordered_map<std::string, std::string>& parameters)
-    {
-        for (const auto& param : mandatoryParameterNames)
+        bool contains(const std::string& name) const
         {
-            if (parameters.find(param) == parameters.end())
+            return _parameters.find(name) != _parameters.end();
+        }
+
+        std::string find(const std::string& name) const
+        {
+            return _parameters.find(name)->second;
+        }
+
+        bool hasConfigurationError() const
+        {
+            return _hasConfigurationError;
+        }
+
+    private:
+        bool _hasConfigurationError = false;
+        std::unordered_map<std::string, std::string> _parameters;
+
+        void checkForMandatoryParameters(const std::unordered_map<std::string, std::string>& parameters)
+        {
+            for (const auto& param : mandatoryParameterNames)
             {
-                std::cerr << "Missing mandatory parameter " << param << std::endl;
+                if (parameters.find(param) == parameters.end())
+                {
+                    std::cerr << "Missing mandatory parameter " << param << std::endl;
+                    _hasConfigurationError = true;
+                }
+            }
+        }
+
+        void checkForExtraParameters(const std::unordered_map<std::string, std::string>& parameters)
+        {
+            for (const auto& parameter : parameters)
+            {
+                if (std::find(mandatoryParameterNames.begin(), mandatoryParameterNames.end(), parameter.first) != mandatoryParameterNames.end()) {
+                    continue;
+                }
+
+                if (std::find(optionalParameterNames.begin(), optionalParameterNames.end(), parameter.first) != optionalParameterNames.end()) {
+                    continue;
+                }
+
+                std::cerr << "Unexpected additional parameter: " << parameter.first << " " << parameter.second << std::endl;
                 _hasConfigurationError = true;
             }
         }
-    }
+    };
 
-    void checkForExtraParameters(const std::unordered_map<std::string, std::string>& parameters)
+    bool configureConnection(const ParameterParser& parameters)
     {
-        for (const auto& parameter : parameters)
+        if (!parameters.contains("--thumbprint")
+            && !parameters.contains("--common-name"))
         {
-            if (std::find(mandatoryParameterNames.begin(), mandatoryParameterNames.end(), parameter.first) != mandatoryParameterNames.end()) {
-                continue;
-            }
-
-            if (std::find(optionalParameterNames.begin(), optionalParameterNames.end(), parameter.first) != optionalParameterNames.end()) {
-                continue;
-            }
-
-            std::cerr << "Unexpected additional parameter: " << parameter.first << " " << parameter.second << std::endl;
-            _hasConfigurationError = true;
+            // We have neither value - and that's ok
+            return true;
         }
-    }
-};
 
-bool configureConnection(const ParameterParser& parameters)
-{
-    if (!parameters.contains("--thumbprint")
-        && !parameters.contains("--common-name"))
-    {
-        // We have neither value - and that's ok
+        if (!parameters.contains("--thumbprint"))
+        {
+            std::cerr << "--thumbprint must also be used when --common-name is used" << std::endl;
+            return false;
+        }
+
+        if (!parameters.contains("--common-name"))
+        {
+            std::cerr << "--common-name must also be used when --thumbprint is used" << std::endl;
+            return false;
+        }
+
+        auto thumbprintParameter = parameters.find("--thumbprint");
+        auto commonNameParameter = parameters.find("--common-name");
+
+        Microsoft::Azure::Batch::SoftwareEntitlement::AddSslCertificate(thumbprintParameter, commonNameParameter);
         return true;
     }
 
-    if (!parameters.contains("--thumbprint"))
+    std::string readToken(ParameterParser& parameters)
     {
-        std::cerr << "--thumbprint must also be used when --common-name is used" << std::endl;
-        return false;
-    }
-
-    if (!parameters.contains("--common-name"))
-    {
-        std::cerr << "--common-name must also be used when --thumbprint is used" << std::endl;
-        return false;
-    }
-
-    auto thumbprintParameter = parameters.find("--thumbprint");
-    auto commonNameParameter = parameters.find("--common-name");
-
-    Microsoft::Azure::Batch::SoftwareEntitlement::AddSslCertificate(thumbprintParameter, commonNameParameter);
-    return true;
-}
-
-std::string readToken(ParameterParser& parameters)
-{
-    auto token = parameters.find("--token");
-    if (token == "-")
-    {
-        // Read the token from stdin.
-        if (!std::getline(std::cin, token))
+        auto token = parameters.find("--token");
+        if (token == "-")
         {
-            throw std::runtime_error("Failed to read token from stdin");
+            // Read the token from stdin.
+            if (!std::getline(std::cin, token))
+            {
+                throw std::runtime_error("Failed to read token from stdin");
+            }
         }
-    }
 
-    return token;
+        return token;
+    }
 }
 
 int main(int argc, char** argv)

--- a/src/sesclient.native/sesclient.native.cpp
+++ b/src/sesclient.native/sesclient.native.cpp
@@ -3,41 +3,41 @@
 
 void ShowUsage(const char* exeName)
 {
-    std::cout << exeName << ":" << std::endl;
-    std::cout << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl;
-    std::cout << "Parameters:" << std::endl;
-    std::cout << "    --url <software entitlement server URL>" << std::endl;
-    std::cout << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain>" << std::endl;
-    std::cout << "    --common-name <common name of the certificate with the specified thumbprint>" << std::endl;
-    std::cout << "    --token <software entitlement token to pass to the server>" << std::endl;
-    std::cout << "    --application <name of the license ID being requested>" << std::endl;
+	std::cout << exeName << ":" << std::endl;
+	std::cout << "Contacts the specified Azure Batch software entitlement server to verify the provided token." << std::endl;
+	std::cout << "Parameters:" << std::endl;
+	std::cout << "    --url <software entitlement server URL>" << std::endl;
+	std::cout << "    --thumbprint <thumbprint of a certificate expected in the server's SSL certificate chain (optional)>" << std::endl;
+	std::cout << "    --common-name <common name of the certificate with the specified thumbprint (optional)>" << std::endl;
+	std::cout << "    --token <software entitlement token to pass to the server>" << std::endl;
+	std::cout << "    --application <name of the license ID being requested>" << std::endl;
 }
 
 
 static const std::array<std::string, 3> mandatoryParameterNames = {
-    "--url",
-    "--token",
-    "--application"
+	"--url",
+	"--token",
+	"--application"
 };
 
 struct Initializer
 {
-    Initializer()
-    {
-        int err = Microsoft::Azure::Batch::SoftwareEntitlement::Init();
-        if (err != 0)
-        {
-            throw std::runtime_error(
-                "Microsoft::Azure::Batch::SoftwareEntitlement::Init failed with error " +
-                std::to_string(err)
-            );
-        }
-    }
+	Initializer()
+	{
+		int err = Microsoft::Azure::Batch::SoftwareEntitlement::Init();
+		if (err != 0)
+		{
+			throw std::runtime_error(
+				"Microsoft::Azure::Batch::SoftwareEntitlement::Init failed with error " +
+				std::to_string(err)
+			);
+		}
+	}
 
-    ~Initializer()
-    {
-        Microsoft::Azure::Batch::SoftwareEntitlement::Cleanup();
-    }
+	~Initializer()
+	{
+		Microsoft::Azure::Batch::SoftwareEntitlement::Cleanup();
+	}
 };
 
 auto shouldShowUsage = false;
@@ -118,9 +118,9 @@ std::string ReadToken(const std::unordered_map<std::string, std::string>& parame
 
 int main(int argc, char** argv)
 {
-    try
-    {
-        Initializer init;
+	try
+	{
+		Initializer init;
 
 		auto parameters = ReadParameters(argc, argv);
 		auto token = ReadToken(parameters);


### PR DESCRIPTION
Allow for use of `sesclient` for testing on machines that already have certificates that pass the authentication checks baked into the library.