### PR TITLE
Update build targets and references for .NET Core 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,81 @@
+#
+# EditorConfig is awesome
+#
+# References
+#
+# What is EditorConfig?
+#     http://editorconfig.org/
+#
+# .NET Coding Convention Settings For EditorConfig
+#     https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/ide/editorconfig-code-style-settings-reference.md
+#
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = false
+# Don't use tabs for indentation.
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+
+[{*proj,*.xml,*.config}]
+indent_size = 2
+
+[{*.json,*.js}]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# CSharp code style settings:
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-    <OutputPath>$(MSBuildProjectDirectory)\..\..\out\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <OutputPath>$(MSBuildProjectDirectory)\..\..\out\$(MSBuildProjectName)\$(Configuration)\$(Platform)</OutputPath>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <Company>Microsoft</Company>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,0 +1,10 @@
+<Project>
+ <PropertyGroup>
+    <OutputPath>$(MSBuildProjectDirectory)\..\..\out\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <DebugType>full</DebugType>
+    <DebugSymbols>True</DebugSymbols>
+    <Company>Microsoft</Company>
+    <Authors>Azure Batch</Authors>
+    <Product>Azure Batch Software Entitlement Service SDK</Product>
+</PropertyGroup>
+</Project>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -4,18 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Common\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_5</DefineConstants>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Common\Release\</OutputPath>
-    <DefineConstants>TRACE;RELEASE;NETSTANDARD1_5</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -18,20 +18,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.1.0-dev-00713" />
-    <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -11,11 +11,6 @@
     <StartupObject />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Remove="Properties\launchSettings.json" />
   </ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         [SuppressMessage("Redundancy", "RCS1163:Unused parameter.")]
+        [SuppressMessage("Redundancies in Symbol Declarations", "RECS0154:Parameter is never used")]
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddProvider(_provider);

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
@@ -33,9 +33,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        [SuppressMessage("Redundancy", "RCS1163:Unused parameter.")]
-        [SuppressMessage("Redundancies in Symbol Declarations", "RECS0154:Parameter is never used")]
+        [SuppressMessage(
+            "Redundancy", "RCS1163:Unused parameter.", Justification = "This method gets called by the ASP.NET runtime. ")]
+        [SuppressMessage(
+            "Redundancies in Symbol Declarations", "RECS0154:Parameter is never used", Justification = "This method gets called by the ASP.NET runtime. ")]
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddProvider(_provider);

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -4,18 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_5</DefineConstants>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement\Release\</OutputPath>
-    <DefineConstants>TRACE;RELEASE;NETSTANDARD1_5</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -18,14 +18,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -10,16 +10,6 @@
     <AssemblyName>sestest</AssemblyName>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out\sestest\Debug\</OutputPath>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out\sestest\Release\</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <Company>Microsoft</Company>
-    <Authors>Azure Batch</Authors>
-    <Product>Azure Batch Software Entitlement Service SDK</Product>
     <RootNamespace>Microsoft.Azure.Batch.SoftwareEntitlement</RootNamespace>
     <AssemblyName>sestest</AssemblyName>
   </PropertyGroup>

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Azure Batch</Authors>
     <Product>Azure Batch Software Entitlement Service SDK</Product>

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -24,19 +24,19 @@
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.1.0-dev-00713" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -15,19 +15,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="Castle.Core" Version="4.1.1" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="2.5.6" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
+    <PackageReference Include="ReportGenerator" Version="2.5.11" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -4,16 +4,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests\Debug\</OutputPath>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests\Release\</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.1.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -4,16 +4,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Tests\Debug\</OutputPath>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\out\Microsoft.Azure.Batch.SoftwareEntitlement.Tests\Release\</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.1.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -15,16 +15,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="Castle.Core" Version="4.1.1" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="2.5.6" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.3.0" />
+    <PackageReference Include="ReportGenerator" Version="2.5.11" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="ReportGenerator" Version="2.5.11" />
     <PackageReference Include="Roslynator.Analyzers" Version="1.4.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
* Update libraries to target `netstandard2.0` and **sestest** to target `netcoreapp2.0`
* Update NuGet package references to the latest version
* Add an `.editorconfig` file to define conventions