### PR TITLE
Document the changes for the next version of the SES API

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -1,14 +1,8 @@
 # REST API for the Software Entitlement Service
 
-Reference documentation for the current version of the REST API supported by the Software Entitlement Service. For historical versions, see the end of this document.
+Reference documentation for the current version of the REST API supported by the Software Entitlement Service. For historical versions and a list of changes, see the end of this document.
 
-## Changes in this version
-
-Changes in this version of the REST API are:
-
-* Removal of the `vmid` value from the response to a successful entitlement verification request.
-
-## Token Verification
+ Token Verification
 
 Verifies that a provided software entitlement token grants permission to use a specific application.
 
@@ -89,3 +83,9 @@ The service will return HTTP status 400 and the response body will be empty if:
 For prior versions of the REST API, see the following pages:
 
 * Initial release, July 2017: [API Version 2017-05-01.5.0](rest-api-2017-05-01.5.0.md)
+
+### Changes in this version
+
+Changes in this version of the REST API are:
+
+* Removal of the `vmid` value from the response to a successful entitlement verification request.

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -14,10 +14,10 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-99-99-9.9`
 
-| Placeholder | Type   | Description                                                                                                                                                                                     |
-| ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
-| version     | string | The API version of the request. <br/> Must be `2017-99-99.9.9`. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| Placeholder |  Type  |                                                                                                                                   Description                                                                                                                                    |
+| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                                                                                                 |
+| version     | string | The API version of the request. <br/> Specify version `2017-99-99.9.9` or higher. <br/> For older API versions, see the end of this document. <br/> All Batch API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
 
 The following shows a sample JSON payload for the request:
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -44,12 +44,14 @@ The following example shows a sample JSON response:
 ``` json
 {
     "id": "entitlement-24223578-1CE8-4168-91E0-126C2D5EAA0B",
+    "expiry": "2017-07-21T01:47:38.4420202Z"
 }
 ```
 
-| Element | Required  | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ------- | --------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id      | Mandatory | string | A unique identifier for the specific entitlement issued to the application. <br/> Multiple entitlement requests for the same application from the same compute node may (but are not required to) return the same identifier. <br/> Entitlement requests from different compute nodes will not return duplicate identifiers. <br/> Clients should make no assumptions about the structure of the `id` as it may change from release to release. |
+| Element | Required  |   Type   |                                                                                                                                                                                                                   Description                                                                                                                                                                                                                   |
+| ------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id      | Mandatory | string   | A unique identifier for the specific entitlement issued to the application. <br/> Multiple entitlement requests for the same application from the same compute node may (but are not required to) return the same identifier. <br/> Entitlement requests from different compute nodes will not return duplicate identifiers. <br/> Clients should make no assumptions about the structure of the `id` as it may change from release to release. |
+| expiry  | Mandatory | DateTime | The expiry timestamp of the token; further verification requests after this instant will be declined.                                                                                                                                                                                                                                                                                                                                           |
 
 ### RESPONSE 403 - FORBIDDEN
 
@@ -89,3 +91,5 @@ For prior versions of the REST API, see the following pages:
 Changes in this version of the REST API are:
 
 * Removal of the `vmid` value from the response to a successful entitlement verification request.
+* Addition of the `expiry` value to the response, giving visibility of the scheduled token expiry.
+

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -17,7 +17,7 @@ Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-versio
 | Placeholder | Type   | Description                                                                                                                                                                                     |
 | ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
-| version     | string | The API version of the request. <br/> Must be `2017-99-99.9.9` or higher. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| version     | string | The API version of the request. <br/> Must be `2017-99-99.9.9`. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
 
 The following shows a sample JSON payload for the request:
 
@@ -51,11 +51,17 @@ The following example shows a sample JSON response:
 | Element | Required  |   Type   |                                                                                                                                                                                                                   Description                                                                                                                                                                                                                   |
 | ------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id      | Mandatory | string   | A unique identifier for the specific entitlement issued to the application. <br/> Multiple entitlement requests for the same application from the same compute node may (but are not required to) return the same identifier. <br/> Entitlement requests from different compute nodes will not return duplicate identifiers. <br/> Clients should make no assumptions about the structure of the `id` as it may change from release to release. |
-| expiry  | Mandatory | DateTime | The expiry timestamp of the token; further verification requests after this instant will be declined.                                                                                                                                                                                                                                                                                                                                           |
+| expiry  | Mandatory | DateTime | The timestamp when the token expires. Once the token has expired, further verification requests will be declined.                                                                                                                                                                                                                                                                                                                               |
 
 ### RESPONSE 403 - FORBIDDEN
 
 If the token does not grant permission to use the requested application, the service will return HTTP status 403 and the response body will contain extended error information.
+
+An entitlement request may be denied if:
+
+* The token has already expired;
+* The requested application is not included in the token; or
+* The token was issued to a different compute node.
 
 The following example shows a sample JSON response:
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
@@ -18,7 +18,7 @@ Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-versio
 | Placeholder | Type   | Description                                                                                                                                                                                     |
 | ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
-| version     | string | The API version of the request. <br/> Must be `2017-05-01.5.0` or higher. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| version     | string | The API version of the request. <br/> Must be `2017-05-01.5.0`. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
 
 The following shows a sample JSON payload for the request:
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
@@ -1,12 +1,7 @@
 # REST API for the Software Entitlement Service
 
-Reference documentation for the current version of the REST API supported by the Software Entitlement Service. For historical versions, see the end of this document.
-
-## Changes in this version
-
-Changes in this version of the REST API are:
-
-* Removal of the `vmid` value from the response to a successful entitlement verification request.
+:warning: This is historical reference documentation for the initial release of Software Entitlement Service REST API, based on the Azure Batch API version number `2017-05-01.5.0`.
+For new implementations, please see the [current REST API documentation](readme.md).
 
 ## Token Verification
 
@@ -18,12 +13,12 @@ Verifies that a provided software entitlement token grants permission to use a s
 | ------ | ------------------------------------------------------ |
 | POST   | {endpoint}/softwareEntitlements/?api-version={version} |
 
-Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-99-99-9.9`
+Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
 | Placeholder | Type   | Description                                                                                                                                                                                     |
 | ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
-| version     | string | The API version of the request. <br/> Must be `2017-99-99.9.9` or higher. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| version     | string | The API version of the request. <br/> Must be `2017-05-01.5.0` or higher. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
 
 The following shows a sample JSON payload for the request:
 
@@ -50,12 +45,14 @@ The following example shows a sample JSON response:
 ``` json
 {
     "id": "entitlement-24223578-1CE8-4168-91E0-126C2D5EAA0B",
+    "vmid": "..."
 }
 ```
 
 | Element | Required  | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ------- | --------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id      | Mandatory | string | A unique identifier for the specific entitlement issued to the application. <br/> Multiple entitlement requests for the same application from the same compute node may (but are not required to) return the same identifier. <br/> Entitlement requests from different compute nodes will not return duplicate identifiers. <br/> Clients should make no assumptions about the structure of the `id` as it may change from release to release. |
+| vmid    | Mandatory | string | The unique [virtual machine identifier](https://azure.microsoft.com/blog/accessing-and-using-azure-vm-unique-id/) of the entitled Azure virtual machine. <br/> Clients may optionally check this matches the actual virtual machine identifier for the host machine.                                                                                                                                                                          |
 
 ### RESPONSE 403 - FORBIDDEN
 
@@ -83,9 +80,3 @@ The service will return HTTP status 400 and the response body will be empty if:
 * The software entitlement token is missing, invalid, or corrupt;
 * The request is badly formed; or
 * The `api-version` specified on the URL is invalid.
-
-## Historical Versions
-
-For prior versions of the REST API, see the following pages:
-
-* Initial release, July 2017: [API Version 2017-05-01.5.0](rest-api-2017-05-01.5.0.md)

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/rest-api-2017-05-01.5.0.md
@@ -15,10 +15,10 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-05-01.5.0`
 
-| Placeholder | Type   | Description                                                                                                                                                                                     |
-| ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                |
-| version     | string | The API version of the request. <br/> Must be `2017-05-01.5.0`. <br/>API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| Placeholder |  Type  |                                                                            Description                                                                             |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                   |
+| version     | string | The API version of the request. <br/> Specify `2017-05-01.5.0` for this version of the API. <br/> For the latest version of this API, see the [readme](readme.md). |
 
 The following shows a sample JSON payload for the request:
 


### PR DESCRIPTION
Changes include removing `vmid` and adding `expiry` to the response for a successful verification.

The actual `api-version` is yet to be determined.