### PR TITLE
Make the virtual machine identifier optional

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -1,5 +1,9 @@
 # Release History
 
+## TBC
+
+* **Change**: Virtual machine identifier is now optional
+
 ## July 2017
 
 Critical (but small) fixes to the SDK.

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -47,7 +47,7 @@ In production, Azure Batch will generate a software entitlement token and make i
 Run the following command to generate a minimal token and store it in `token.txt`:
 
 ``` PowerShell
-PS> .\sestest generate --vmid $env:COMPUTERNAME --application-id contosoapp --token-file token.txt
+PS> .\sestest generate --application-id contosoapp --token-file token.txt
 10:18:27.531 [Information] ---------------------------------------------
 10:18:27.548 [Information]   Software Entitlement Service Test Utility
 10:18:27.548 [Information] ---------------------------------------------
@@ -96,7 +96,7 @@ Defining these variables makes it easier to type the commands and reducing the o
 Add the options `--sign` and `--encrypt` to the command line used above to generate a fully secured token:
 
 ``` PowerShell
-PS> .\sestest generate --vmid $env:COMPUTERNAME --application-id contosoapp --sign $signingThumbprint --encrypt $encryptingThumbprint --token-file token.txt
+PS> .\sestest generate --application-id contosoapp --sign $signingThumbprint --encrypt $encryptingThumbprint --token-file token.txt
 14:06:43.861 [Information] ---------------------------------------------
 14:06:43.861 [Information]   Software Entitlement Service Test Utility
 14:06:43.861 [Information] ---------------------------------------------
@@ -111,7 +111,7 @@ As we did above, set the environment variable `AZ_BATCH_SOFTWARE_ENTITLEMENT_TOK
 PS> $env:AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN = (get-content token.txt)
 ```
 
-Testing with an encrypted token is useful because these are significantly longer, in part due to information about the required key that's included within. Note that your application doesn't need to do anything different with encrypted vs unencrypted tokens.
+Testing with an encrypted token is useful because these are significantly longer, in part due to information about the required key that's included within. This may reveal issues (such as buffer sizes that are too small) that an unencrypted token would not. Note that your application doesn't need to do anything different with encrypted vs unencrypted tokens.
 
 ## Starting the test server
 

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -111,7 +111,7 @@ As we did above, set the environment variable `AZ_BATCH_SOFTWARE_ENTITLEMENT_TOK
 PS> $env:AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN = (get-content token.txt)
 ```
 
-Testing with an encrypted token is useful because these are significantly longer, in part due to information about the required key that's included within. This may reveal issues (such as buffer sizes that are too small) that an unencrypted token would not. Note that your application doesn't need to do anything different with encrypted vs unencrypted tokens.
+Testing with an encrypted token is useful because these are significantly longer, in part due to information about the required key that's included within. (This may reveal issues, such as buffer sizes that are too small, that an unencrypted token would not.) Note that your application doesn't need to do anything different with encrypted vs unencrypted tokens. 
 
 ## Starting the test server
 

--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("application-id", HelpText = "Unique identifier(s) for the applications(s) to include in the entitlement (comma separated).", Separator = ',')]
         public IList<string> ApplicationIds { get; set; } = new List<string>();
 
-        [Option("vmid", HelpText = "Unique identifier for the Azure virtual machine.")]
+        [Option("vmid", HelpText = "[Deprecated] Unique identifier for the Azure virtual machine.")]
         public string VirtualMachineId { get; set; }
 
         [Option(

--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using CommandLine;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("application-id", HelpText = "Unique identifier(s) for the applications(s) to include in the entitlement (comma separated).", Separator = ',')]
         public IList<string> ApplicationIds { get; set; } = new List<string>();
 
-        [Option("vmid", HelpText = "Unique identifier for the Azure virtual machine (mandatory).")]
+        [Option("vmid", HelpText = "Unique identifier for the Azure virtual machine.")]
         public string VirtualMachineId { get; set; }
 
         [Option(

--- a/src/sestest/NodeEntitlementsBuilder.cs
+++ b/src/sestest/NodeEntitlementsBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,30 +55,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var entitlement = new NodeEntitlements();
             var errors = new List<string>();
 
-            // readConfiguration - function to read the configuration value
-            // applyConfiguration - function to modify our configuration with the value read
-            void Configure<V>(Func<Errorable<V>> readConfiguration, Func<V, NodeEntitlements> applyConfiguration)
-            {
-                readConfiguration().Match(
-                    whenSuccessful: value => entitlement = applyConfiguration(value),
-                    whenFailure: e => errors.AddRange(e));
-            }
-
-            // readConfiguration - function to read all the configuration values
-            // applyConfiguration - function to modify our configuration with each value read
-            void ConfigureAll<V>(
-                Func<IEnumerable<Errorable<V>>> readConfiguration,
-                Func<V, NodeEntitlements> applyConfiguration)
-            {
-                foreach (var configuration in readConfiguration())
-                {
-                    configuration.Match(
-                            whenSuccessful: value => entitlement = applyConfiguration(value),
-                            whenFailure: e => errors.AddRange(e));
-                }
-            }
-
-            Configure(VirtualMachineId, url => entitlement.WithVirtualMachineId(url));
+            ConfigureOptional(VirtualMachineId, url => entitlement.WithVirtualMachineId(url));
             Configure(NotBefore, notBefore => entitlement.FromInstant(notBefore));
             Configure(NotAfter, notAfter => entitlement.UntilInstant(notAfter));
             Configure(Audience, audience => entitlement.WithAudience(audience));
@@ -92,13 +69,53 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             return Errorable.Success(entitlement);
+
+            // <param name="readConfiguration">function to read the configuration value.</param>
+            // <param name="applyConfiguration">function to modify our configuration with the value read.</param>
+            void Configure<V>(Func<Errorable<V>> readConfiguration, Func<V, NodeEntitlements> applyConfiguration)
+            {
+                readConfiguration().Match(
+                    whenSuccessful: value => entitlement = applyConfiguration(value),
+                    whenFailure: e => errors.AddRange(e));
+            }
+
+            // <param name="readConfiguration">function to read the configuration value.</param>
+            // <param name="applyConfiguration">function to modify our configuration with the value read.</param>
+            void ConfigureOptional<V>(Func<Errorable<V>> readConfiguration, Func<V, NodeEntitlements> applyConfiguration)
+                where V : class
+            {
+                readConfiguration().Match(
+                    whenSuccessful: value =>
+                    {
+                        if (value != null)
+                        {
+                            entitlement = applyConfiguration(value);
+                        }
+                    },
+                    whenFailure: e => errors.AddRange(e));
+            }
+
+            // <param name="readConfiguration">function to read the configuration value.</param>
+            // <param name="applyConfiguration">function to modify our configuration with the value read.</param>
+            void ConfigureAll<V>(
+                Func<IEnumerable<Errorable<V>>> readConfiguration,
+                Func<V, NodeEntitlements> applyConfiguration)
+            {
+                foreach (var configuration in readConfiguration())
+                {
+                    configuration.Match(
+                        whenSuccessful: value => entitlement = applyConfiguration(value),
+                        whenFailure: e => errors.AddRange(e));
+                }
+            }
         }
 
         private Errorable<string> VirtualMachineId()
         {
             if (string.IsNullOrEmpty(_commandLine.VirtualMachineId))
             {
-                return Errorable.Failure<string>("No virtual machine identifier specified.");
+                // If user doesn't specify a virtual machine identifier, we default to null (not empty string)
+                return Errorable.Success<string>(null);
             }
 
             return Errorable.Success(_commandLine.VirtualMachineId);
@@ -130,6 +147,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             if (string.IsNullOrEmpty(_commandLine.Audience))
             {
+                // if the audience does not specify an audience, we use a default value to "self-sign"
                 return Errorable.Success(Claims.DefaultAudience);
             }
 
@@ -140,6 +158,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             if (string.IsNullOrEmpty(_commandLine.Issuer))
             {
+                // if the audience does not specify an issuer, we use a default value to "self-sign"
                 return Errorable.Success(Claims.DefaultIssuer);
             }
 
@@ -152,19 +171,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             {
                 foreach (var address in _commandLine.Addresses)
                 {
-                    if (IPAddress.TryParse(address, out var ip))
-                    {
-                        yield return Errorable.Success(ip);
-                    }
-                    else
-                    {
-                        yield return Errorable.Failure<IPAddress>($"IP address '{address}' not in expected format (IPv4 and IPv6 supported).");
-                    }
+                    yield return TryParseIPAddress(address);
                 }
 
                 yield break;
             }
 
+            // No IP addresses specified by the user, default to using all from the current machine
             foreach (var i in NetworkInterface.GetAllNetworkInterfaces())
             {
                 var properties = i.GetIPProperties();
@@ -182,6 +195,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                     }
                 }
             }
+        }
+
+        private static Errorable<IPAddress> TryParseIPAddress(string address)
+        {
+            if (IPAddress.TryParse(address, out var ip))
+            {
+                return Errorable.Success(ip);
+            }
+
+            return Errorable.Failure<IPAddress>($"IP address '{address}' not in expected format (IPv4 and IPv6 supported).");
         }
 
         private IEnumerable<Errorable<string>> Applications()

--- a/src/sestest/NodeEntitlementsBuilder.cs
+++ b/src/sestest/NodeEntitlementsBuilder.cs
@@ -167,16 +167,25 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
         private IEnumerable<Errorable<IPAddress>> Addresses()
         {
-            if (_commandLine.Addresses != null && _commandLine.Addresses.Any())
+            var result = new List<Errorable<IPAddress>>();
+            if (_commandLine.Addresses != null)
             {
                 foreach (var address in _commandLine.Addresses)
                 {
-                    yield return TryParseIPAddress(address);
+                    result.Add(TryParseIPAddress(address));
                 }
-
-                yield break;
             }
 
+            if (!result.Any())
+            {
+                result.AddRange(ListMachineIpAddresses());
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<Errorable<IPAddress>> ListMachineIpAddresses()
+        {
             // No IP addresses specified by the user, default to using all from the current machine
             foreach (var i in NetworkInterface.GetAllNetworkInterfaces())
             {
@@ -204,7 +213,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 return Errorable.Success(ip);
             }
 
-            return Errorable.Failure<IPAddress>($"IP address '{address}' not in expected format (IPv4 and IPv6 supported).");
+            return Errorable.Failure<IPAddress>($"IP address '{address}' is not in an expected format (IPv4 and IPv6 supported).");
         }
 
         private IEnumerable<Errorable<string>> Applications()

--- a/src/sestest/readme.md
+++ b/src/sestest/readme.md
@@ -67,16 +67,16 @@ The additional parameters `--audience` and `--issuer`  are provided for use by t
 
 The `generate` mode allows you to generate a software entitlement token with the details required for your test scenario.
 
-| Parameter     | Required  | Definition                                                                                                                                                                           |
-| ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| --application | Mandatory | Unique identifier(s) for the application(s) to include (comma separated).                                                                                                            |
-| --vmid        | Mandatory | Unique identifier for the Azure virtual machine. If you are testing outside of Azure, we suggest you use the name of the machine (e.g. `%COMPUTERNAME%`).                            |
-| --not-before  | Optional  | The moment at which the token becomes active and the application is entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to now.                |
-| --not-after   | Optional  | The moment at which the token expires and the application is no longer entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to 7 days from now. |
-| --address     | Optional  | The IP addresses of the machine entitled to execute the application(s). <br/> Defaults to all the IP addresses of the current machine.                                               |
-| --sign        | Optional  | Thumbprint of the certificate to use for signing the token                                                                                                                           |
-| --encrypt     | Optional  | Thumbprint of the certificate to use for encryption of the token.                                                                                                                    |
-| --token-file  | Optional  | The name of a file into which the token will be written <br/> If not specified, the token will be shown in the log.                                                                  |
+|   Parameter   | Required  |                                                                                                                Definition                                                                                                                 |
+| ------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --application | Mandatory | Unique identifier(s) for the application(s) to include (comma separated).                                                                                                                                                                 |
+| --not-before  | Optional  | The moment at which the token becomes active and the application is entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to now.                                                                     |
+| --not-after   | Optional  | The moment at which the token expires and the application is no longer entitled to execute <br/> Format: 'yyyy-mm-ddThh-mm'; 24 hour clock; local time; defaults to 7 days from now.                                                      |
+| --address     | Optional  | The IP addresses of the machine entitled to execute the application(s). <br/> Defaults to all the IP addresses of the current machine.                                                                                                    |
+| --sign        | Optional  | Thumbprint of the certificate to use for signing the token                                                                                                                                                                                |
+| --encrypt     | Optional  | Thumbprint of the certificate to use for encryption of the token.                                                                                                                                                                         |
+| --token-file  | Optional  | The name of a file into which the token will be written <br/> If not specified, the token will be shown in the log.                                                                                                                       |
+| --vmid        | Optional  | **Deprecated** Unique identifier for the Azure virtual machine (only available on IaaS VMs). <br/> If you are testing outside of Azure, we suggest you either omit this parameter or use the name of the machine (e.g. `%COMPUTERNAME%`). |
 
 You can see this documentation for yourself by running `sestest generate --help` in your console.
 

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/NodeEntitlementsBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using FluentAssertions;
@@ -45,19 +45,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         public class VirtualMachineIdProperty : NodeEntitlementsBuilderTests
         {
             [Fact]
-            public void WhenMissing_BuildDoesNotReturnValue()
+            public void WhenMissing_BuildReturnsValue()
             {
                 _commandLine.VirtualMachineId = null;
                 var entitlement = NodeEntitlementsBuilder.Build(_commandLine);
-                entitlement.HasValue.Should().BeFalse();
+                entitlement.HasValue.Should().BeTrue();
             }
 
             [Fact]
-            public void WhenMissing_BuildReturnsErrorForVirtualMachineId()
+            public void WhenMissing_BuildReturnsEntitlementWithNoVirtualMachineId()
             {
                 _commandLine.VirtualMachineId = null;
                 var entitlement = NodeEntitlementsBuilder.Build(_commandLine);
-                entitlement.Errors.Should().Contain(e => e.Contains("virtual machine identifier"));
+                entitlement.Value.VirtualMachineId.Should().BeNullOrEmpty();
             }
 
             [Fact]

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenEnforcementTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -203,13 +203,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             }
 
             [Fact]
-            public void WhenIdentifierOmitted_ReturnsError()
+            public void WhenIdentifierOmitted_EntitlementHasNoVirtualMachineIdentifier()
             {
                 var entitlements = CreateEntitlements(EntitlementCreationOptions.OmitMachineId);
                 var token = _generator.Generate(entitlements);
                 var result = _verifier.Verify(token, _audience, _issuer, _contosoFinanceApp, _approvedAddress);
-                result.HasValue.Should().BeFalse();
-                result.Errors.Should().Contain(e => e.Contains("machine identifier"));
+                result.HasValue.Should().BeTrue();
+                result.Value.VirtualMachineId.Should().BeNullOrEmpty();
             }
         }
 

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenGeneratorTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/TokenGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         public class Generate : TokenGeneratorTests
         {
             private readonly TokenGenerator _generator;
+
 
             public Generate()
             {


### PR DESCRIPTION
We're deprecating **vmid** (see #63).