### PR TITLE
Improve integration test script

### DIFF
--- a/integration-test.ps1
+++ b/integration-test.ps1
@@ -62,9 +62,31 @@ start-process powershell -argument $command
 
 # ----------------------------------------------------------------------
 
-Write-TaskName "Wait 5s for server to be up"
+Write-TaskName "Wait for server to be up"
 
-start-sleep -seconds 5
+function check-serverActive {
+    $address = [System.Net.IPAddress]('127.0.0.1')
+    $port = 4443
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $client.Connect($address, $port);
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        $client.Dispose();
+    }
+}
+
+$ready = check-serverActive
+while (!$ready) {
+    Write-Output "Waiting ..."
+    $ready = check-serverActive
+} 
+
+Write-Output "Server now active"
 
 # ----------------------------------------------------------------------
 

--- a/integration-test.ps1
+++ b/integration-test.ps1
@@ -32,7 +32,7 @@ if ($thumbprint -eq $null) {
 
 function Write-TaskName($subtaskName) {
     $divider = "-" * ($subtaskName.Length + 4)
-    Write-Output "`r`n$divider`r`n  $subtaskName`r`n$divider"
+    Write-Output "`r`n$divider`r`n  $subtaskName`r`n$divider`r`n"
 }
 
 # ----------------------------------------------------------------------
@@ -59,6 +59,8 @@ Write-TaskName "Start Software Entitlement Server"
 
 $command = ".\sestest.ps1 server --connection $thumbprint --sign $thumbprint --encrypt $thumbprint --exit-after-request --log-file server.log --log-file-level debug"
 start-process powershell -argument $command
+
+Write-Output "Server started successfully."
 
 # ----------------------------------------------------------------------
 
@@ -96,6 +98,7 @@ Write-TaskName "Verify Token"
 
 if ($LASTEXITCODE -ne 0) {
     Write-Output "Token did not verify (Error code $LASTEXITCODE)"
+    Write-Output "(You'll need to manually stop the server.)"
 } else {
     Write-Output "Token verified ok"
 }


### PR DESCRIPTION
Instead of hard coding a 5 second wait, check to see if the server is listening on the appropriate port. 
Plus, some improvements to output when running.