### PR TITLE
Update SDK to next API version

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,10 +1,11 @@
 <Project>
- <PropertyGroup>
-    <OutputPath>$(MSBuildProjectDirectory)\..\..\out\$(MSBuildProjectName)\$(Configuration)\$(Platform)</OutputPath>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-    <Company>Microsoft</Company>
-    <Authors>Azure Batch</Authors>
-    <Product>Azure Batch Software Entitlement Service SDK</Product>
-</PropertyGroup>
+    <PropertyGroup>
+        <OutputPath>$(MSBuildProjectDirectory)\..\..\out\$(MSBuildProjectName)\$(Configuration)\$(Platform)</OutputPath>
+        <DebugType>full</DebugType>
+        <DebugSymbols>True</DebugSymbols>
+        <Company>Microsoft</Company>
+        <Authors>Azure Batch</Authors>
+        <Product>Azure Batch Software Entitlement Service SDK</Product>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 </Project>

--- a/azure-batch-software-entitlement.sln
+++ b/azure-batch-software-entitlement.sln
@@ -15,7 +15,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{911185B0-089A-4FBA-BC82-3161918307A5}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.build.props = Directory.build.props
+		sesclient.ps1 = sesclient.ps1
 		sestest.cmd = sestest.cmd
+		sestest.ps1 = sestest.ps1
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sestest", "src\sestest\sestest.csproj", "{8CAE3A3B-DEB1-4042-8444-80369FAB20E8}"

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
@@ -115,6 +115,43 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
                     whenFailure: errors => Errorable.Failure<(A, B, C)>(leftErrors).AddErrors(errors)));
         }
 
+        /// <summary>
+        /// Combine two <see cref="Errorable{T}"/> values into a single value containing a tuple 
+        /// of three values
+        /// </summary>
+        /// <remarks>
+        /// Works as a logical <c>AND</c> - if both inputs are successful, the output is successful; 
+        /// if either input is a failure, the output is a failure. All error messages are preserved.
+        /// </remarks>
+        /// <typeparam name="A">Type of the first value held by <paramref name="left"/>.</typeparam>
+        /// <typeparam name="B">Type of the second value held by <paramref name="left"/>.</typeparam>
+        /// <typeparam name="C">Type of the third value held by <paramref name="left"/>.</typeparam>
+        /// <typeparam name="D">Type of value held by <paramref name="right"/>.</typeparam>
+        /// <param name="left">First <see cref="Errorable{T}"/> to combine.</param>
+        /// <param name="right">Second <see cref="Errorable{T}"/> to combine.</param>
+        /// <returns>An <see cref="Errorable{T}"/> containing either all three values or a 
+        /// combined set of error messages.</returns>
+        public static Errorable<(A, B, C, D)> And<A, B, C, D>(this Errorable<(A, B, C)> left, Errorable<D> right)
+        {
+            if (left == null)
+            {
+                throw new ArgumentNullException(nameof(left));
+            }
+
+            if (right == null)
+            {
+                throw new ArgumentNullException(nameof(right));
+            }
+
+            return left.Match(
+                whenSuccessful: leftValue => right.Match(
+                    whenSuccessful: rightValue => Errorable.Success((leftValue.Item1, leftValue.Item2, leftValue.Item3, rightValue)),
+                    whenFailure: errors => Errorable.Failure<(A, B, C, D)>(errors)),
+                whenFailure: leftErrors => right.Match(
+                    whenSuccessful: _ => Errorable.Failure<(A, B, C, D)>(leftErrors),
+                    whenFailure: errors => Errorable.Failure<(A, B, C, D)>(leftErrors).AddErrors(errors)));
+        }
+
         public static void Do<A, B>(
             this Errorable<(A, B)> errorable,
             Action<A, B> whenSuccessful,
@@ -161,6 +198,29 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             errorable.Match(t => whenSuccessful(t.Item1, t.Item2, t.Item3), whenFailure);
         }
 
+        public static void Do<A, B, C, D>(
+            this Errorable<(A, B, C, D)> errorable,
+            Action<A, B, C, D> whenSuccessful,
+            Action<IEnumerable<string>> whenFailure)
+        {
+            if (errorable == null)
+            {
+                throw new ArgumentNullException(nameof(errorable));
+            }
+
+            if (whenSuccessful == null)
+            {
+                throw new ArgumentNullException(nameof(whenSuccessful));
+            }
+
+            if (whenFailure == null)
+            {
+                throw new ArgumentNullException(nameof(whenFailure));
+            }
+
+            errorable.Match(t => whenSuccessful(t.Item1, t.Item2, t.Item3, t.Item4), whenFailure);
+        }
+
         public static Errorable<R> Map<A, B, R>(
             this Errorable<(A, B)> errorable,
             Func<A, B, R> transform)
@@ -199,9 +259,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
                 e => Errorable.Failure<R>(e));
         }
 
-        public static Task<Errorable<R>> MapAsync<A, B, C, R>(
-            this Errorable<(A, B, C)> errorable,
-            Func<A, B, C, Task<R>> transform)
+        public static Errorable<R> Map<A, B, C, D, R>(
+            this Errorable<(A, B, C, D)> errorable,
+            Func<A, B, C, D, R> transform)
         {
             if (errorable == null)
             {
@@ -214,7 +274,26 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             }
 
             return errorable.Match(
-                async t => Errorable.Success(await transform(t.Item1, t.Item2, t.Item3)),
+                t => Errorable.Success(transform(t.Item1, t.Item2, t.Item3, t.Item4)),
+                e => Errorable.Failure<R>(e));
+        }
+
+        public static Task<Errorable<R>> MapAsync<A, B, C, D, R>(
+            this Errorable<(A, B, C, D)> errorable,
+            Func<A, B, C, D, Task<R>> transform)
+        {
+            if (errorable == null)
+            {
+                throw new ArgumentNullException(nameof(errorable));
+            }
+
+            if (transform == null)
+            {
+                throw new ArgumentNullException(nameof(transform));
+            }
+
+            return errorable.Match(
+                async t => Errorable.Success(await transform(t.Item1, t.Item2, t.Item3, t.Item4)),
                 e => Task.FromResult(Errorable.Failure<R>(e)));
         }
     }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <param name="right">Second <see cref="Errorable{T}"/> to combine.</param>
         /// <returns>An <see cref="Errorable{T}"/> containing either both values or a combined 
         /// set of error messages.</returns>
-        public static Errorable<(A, B)> And<A, B>(this Errorable<A> left, Errorable<B> right)
+        public static Errorable<(A, B)> With<A, B>(this Errorable<A> left, Errorable<B> right)
         {
             if (left == null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <param name="right">Second <see cref="Errorable{T}"/> to combine.</param>
         /// <returns>An <see cref="Errorable{T}"/> containing either all three values or a 
         /// combined set of error messages.</returns>
-        public static Errorable<(A, B, C)> And<A, B, C>(this Errorable<(A, B)> left, Errorable<C> right)
+        public static Errorable<(A, B, C)> With<A, B, C>(this Errorable<(A, B)> left, Errorable<C> right)
         {
             if (left == null)
             {
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <param name="right">Second <see cref="Errorable{T}"/> to combine.</param>
         /// <returns>An <see cref="Errorable{T}"/> containing either all three values or a 
         /// combined set of error messages.</returns>
-        public static Errorable<(A, B, C)> And<A, B, C>(this Errorable<A> left, Errorable<(B, C)> right)
+        public static Errorable<(A, B, C)> With<A, B, C>(this Errorable<A> left, Errorable<(B, C)> right)
         {
             if (left == null)
             {
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <param name="right">Second <see cref="Errorable{T}"/> to combine.</param>
         /// <returns>An <see cref="Errorable{T}"/> containing either all three values or a 
         /// combined set of error messages.</returns>
-        public static Errorable<(A, B, C, D)> And<A, B, C, D>(this Errorable<(A, B, C)> left, Errorable<D> right)
+        public static Errorable<(A, B, C, D)> With<A, B, C, D>(this Errorable<(A, B, C)> left, Errorable<D> right)
         {
             if (left == null)
             {

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 {
@@ -196,6 +197,25 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             return errorable.Match(
                 t => Errorable.Success(transform(t.Item1, t.Item2, t.Item3)),
                 e => Errorable.Failure<R>(e));
+        }
+
+        public static Task<Errorable<R>> MapAsync<A, B, C, R>(
+            this Errorable<(A, B, C)> errorable,
+            Func<A, B, C, Task<R>> transform)
+        {
+            if (errorable == null)
+            {
+                throw new ArgumentNullException(nameof(errorable));
+            }
+
+            if (transform == null)
+            {
+                throw new ArgumentNullException(nameof(transform));
+            }
+
+            return errorable.Match(
+                async t => Errorable.Success(await transform(t.Item1, t.Item2, t.Item3)),
+                e => Task.FromResult(Errorable.Failure<R>(e)));
         }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/LoggerExtensions.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 {
@@ -56,7 +58,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// </summary>
         /// <param name="logger">Actual logger to use.</param>
         /// <param name="errors">Sequence of errors to log.</param>
-        public  static void LogErrors(this ILogger logger, IEnumerable<string> errors)
+        public static void LogErrors(this ILogger logger, IEnumerable<string> errors)
         {
             foreach (var e in errors)
             {
@@ -74,6 +76,34 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             foreach (var m in messages)
             {
                 logger.LogInformation(m);
+            }
+        }
+
+        public static void LogJson(this ILogger logger, string json)
+        {
+            var pretty = JsonPrettify(json).AsLines();
+            logger.LogInformation(pretty);
+        }
+
+        /// <summary>
+        /// Pretty print a JSON string for logging
+        /// </summary>
+        /// <remarks>
+        /// As found on StackOverflow: https://stackoverflow.com/a/30329731/30280
+        /// </remarks>
+        /// <param name="json">JSON string to reformat.</param>
+        /// <returns>Equivalent JSON with nice formatting.</returns>
+        private static string JsonPrettify(string json)
+        {
+            using (var stringReader = new StringReader(json))
+            {
+                using (var stringWriter = new StringWriter())
+                {
+                    var jsonReader = new JsonTextReader(stringReader);
+                    var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.Indented };
+                    jsonWriter.WriteToken(jsonReader);
+                    return stringWriter.ToString();
+                }
             }
         }
     }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/LoggerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 
@@ -16,9 +16,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// Each line is passed as a list of strings, one value per column.
         /// </remarks>
         /// <param name="logger">Actual logger to use.</param>
-        /// <param name="level">Log level for the output.</param>
         /// <param name="lines">Lines to format.</param>
-        public static void LogTable(this ILogger logger, LogLevel level, IEnumerable<IEnumerable<string>> lines)
+        public static void LogInformationTable(this ILogger logger, IEnumerable<IEnumerable<string>> lines)
         {
             const int columnGap = 3;
             var rows = lines.Select(r => r.ToList()).ToList();
@@ -31,15 +30,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             var columnCount = rows.Max(r => r.Count);
             var widths = Enumerable.Range(0, columnCount).Select(ColumnWidth).ToList();
 
-            string FormatRow(IEnumerable<string> cells)
-            {
-                return string.Concat(cells.Select((cell, index) => cell.PadRight(widths[index])))
-                    .TrimEnd();
-            }
-
             foreach (var row in rows)
             {
-                logger.Log(level, (EventId)0, row, null, (cells, ex) => FormatRow(cells));
+                var s = string.Concat(row.Select((cell, index) => cell.PadRight(widths[index])))
+                    .TrimEnd();
+                logger.LogInformation(s);
             }
         }
 
@@ -48,13 +43,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// </summary>
         /// <param name="logger">Actual logger to use.</param>
         /// <param name="heading">Heading to display.</param>
-        /// <param name="level">Log level for the output.</param>
-        public static void LogHeader(this ILogger logger, string heading, LogLevel level = LogLevel.Information)
+        public static void LogHeader(this ILogger logger, string heading)
         {
             var line = new string('-', heading.Length + 4);
-            logger.Log(level, (EventId)0, line, null, (s, ex) => s);
-            logger.Log(level, (EventId)0, "  " + heading, null, (s, ex) => s);
-            logger.Log(level, (EventId)0, line, null, (s, ex) => s);
+            logger.LogInformation(line);
+            logger.LogInformation("  " + heading);
+            logger.LogInformation(line);
         }
 
         /// <summary>
@@ -67,6 +61,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             foreach (var e in errors)
             {
                 logger.LogError(e);
+            }
+        }
+
+        /// <summary>
+        /// Log a series of information messages
+        /// </summary>
+        /// <param name="logger">Actual logger to use.</param>
+        /// <param name="messages">Sequence of messages to log.</param>
+        public static void LogInformation(this ILogger logger, IEnumerable<string> messages)
+        {
+            foreach (var m in messages)
+            {
+                logger.LogInformation(m);
             }
         }
     }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using System;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 {
@@ -14,12 +15,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         public string EntitlementId { get; set; }
 
         /// <summary>
-        /// The virtual machine identifier for the Azure VM entitled to run the software
+        /// [Deprecated] The virtual machine identifier for the Azure VM entitled to run the software
+        /// </summary>
+        [JsonProperty(PropertyName = "vmid", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string VirtualMachineId { get; set; }
+
+        /// <summary>
+        /// Time-stamp of the token's expiry
         /// </summary>
         /// <remarks>
-        /// This may be verified by the calling software package as an (optional) additional check.
+        /// This allows consuming software packages (e.g. schedulers) to make decisions based on 
+        /// how long the token has yet to live
         /// </remarks>
-        [JsonProperty(PropertyName = "vmid")]
-        public string VirtualMachineId { get; set; }
+        [JsonProperty(PropertyName = "expiry", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DateTimeOffset Expiry { get; set; }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/SoftwareEntitlementSuccessfulResponse.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         public string VirtualMachineId { get; set; }
 
         /// <summary>
-        /// Time-stamp of the token's expiry
+        /// Time-stamp of the token's expiry (UTC)
         /// </summary>
         /// <remarks>
         /// This allows consuming software packages (e.g. schedulers) to make decisions based on 
-        /// how long the token has yet to live
+        /// how long the token has yet to live.
         /// </remarks>
         [JsonProperty(PropertyName = "expiry", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTimeOffset Expiry { get; set; }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
         // Verifier used to check tokens
         private readonly TokenVerifier _verifier;
 
+        private const string ApiVersion201705 =  "2017-05-01.5.0";
+        private const string ApiVersion201709 =  "2017-09-01.6.0";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SoftwareEntitlementsController"/> class
         /// </summary>
@@ -124,8 +127,18 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
                 var response = new SoftwareEntitlementSuccessfulResponse
                 {
                     EntitlementId = entitlement.Identifier,
-                    VirtualMachineId = entitlement.VirtualMachineId
+                    
                 };
+
+                if (ApiSupportsVirtualMachineId(apiVersion))
+                {
+                    response.VirtualMachineId = entitlement.VirtualMachineId;
+                }
+
+                if (ApiSupportsExpiryTimestamp(apiVersion))
+                {
+                    response.Expiry = entitlement.NotAfter;
+                }
 
                 return Ok(response);
             }
@@ -153,8 +166,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
 
             // Check all the valid apiVersions
             // TODO: Once this list passes three or four items, use a HashSet<string> to do the check more efficiently
-            return apiVersion.Equals("2017-05-01.5.0", StringComparison.Ordinal)
-                   || apiVersion.Equals("2017-06-01.5.1", StringComparison.Ordinal);
+            
+            return apiVersion.Equals(ApiVersion201705, StringComparison.Ordinal)
+                   || apiVersion.Equals(ApiVersion201709, StringComparison.Ordinal);
+        }
+
+        private bool ApiSupportsVirtualMachineId(string apiVersion)
+        {
+            return string.Equals(apiVersion, ApiVersion201705, StringComparison.Ordinal);
+        }
+
+        private bool ApiSupportsExpiryTimestamp(string apiVersion)
+        {
+            return string.Equals(apiVersion, ApiVersion201709, StringComparison.Ordinal);
         }
 
         public class ServerOptions

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -77,6 +77,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
                     "Selected api-version is {ApiVersion}",
                     apiVersion);
 
+                if (entitlementRequest == null)
+                {
+                    _logger.LogError("No software entitlement request made");
+
+                    var error = new SoftwareEntitlementFailureResponse
+                    {
+                        Code = "EntitlementDenied",
+                        Message = new ErrorMessage("No software entitlement request made.")
+                    };
+
+                    return StatusCode(400, error);
+                }
+
                 _logger.LogInformation(
                     "Requesting entitlement for {Application}",
                     entitlementRequest.ApplicationId);
@@ -132,6 +145,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
         /// <returns>True if it is valid, false otherwise.</returns>
         private bool IsValidApiVersion(string apiVersion)
         {
+            if (string.IsNullOrEmpty(apiVersion))
+            {
+                _logger.LogDebug("No api-version specified");
+                return false;
+            }
+
             // Check all the valid apiVersions
             // TODO: Once this list passes three or four items, use a HashSet<string> to do the check more efficiently
             return apiVersion.Equals("2017-05-01.5.0", StringComparison.Ordinal)

--- a/src/sestest/CommandBase.cs
+++ b/src/sestest/CommandBase.cs
@@ -18,16 +18,5 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
-
-        /// <summary>
-        /// Log a sequence of errors 
-        /// </summary>
-        /// <param name="errors"></param>
-        /// <returns></returns>
-        protected int LogErrors(IEnumerable<string> errors)
-        {
-            Logger.LogErrors(errors);
-            return -1;
-        }
     }
 }

--- a/src/sestest/CommandBase.cs
+++ b/src/sestest/CommandBase.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// Shared code between different commands
+    /// </summary>
+    public abstract class CommandBase
+    {
+        // Reference to our logger
+        protected readonly ILogger Logger;
+
+        protected CommandBase(ILogger logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Log a sequence of errors 
+        /// </summary>
+        /// <param name="errors"></param>
+        /// <returns></returns>
+        protected int LogErrors(IEnumerable<string> errors)
+        {
+            Logger.LogErrors(errors);
+            return -1;
+        }
+    }
+}

--- a/src/sestest/FindCertificateCommand.cs
+++ b/src/sestest/FindCertificateCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 Logger.LogInformation(line);
             }
 
-            return 0;
+            return ResultCodes.Success;
         }
     }
 }

--- a/src/sestest/FindCertificateCommand.cs
+++ b/src/sestest/FindCertificateCommand.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using Microsoft.Extensions.Logging;
 
@@ -24,12 +23,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// </summary>
         /// <param name="commandLine">Configuration from the command line.</param>
         /// <returns>Results of execution (0 = success).</returns>
-        public int Execute(FindCertificateCommandLine commandLine)
+        public Task<int> Execute(FindCertificateCommandLine commandLine)
         {
             var thumbprint = new CertificateThumbprint(commandLine.Thumbprint);
             var certificateStore = new CertificateStore();
             var certificate = certificateStore.FindByThumbprint("required", thumbprint);
-            return certificate.Match(ShowCertificate, LogErrors);
+            var result = certificate.Match(ShowCertificate, LogErrors);
+            return Task.FromResult(result);
         }
 
         private int ShowCertificate(X509Certificate2 certificate)

--- a/src/sestest/FindCertificateCommand.cs
+++ b/src/sestest/FindCertificateCommand.cs
@@ -28,7 +28,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var thumbprint = new CertificateThumbprint(commandLine.Thumbprint);
             var certificateStore = new CertificateStore();
             var certificate = certificateStore.FindByThumbprint("required", thumbprint);
-            var result = certificate.Match(ShowCertificate, LogErrors);
+            var result = certificate.Match(
+                ShowCertificate,
+                errors =>
+                {
+                    Logger.LogErrors(errors);
+                    return ResultCodes.Failed;
+                });
             return Task.FromResult(result);
         }
 

--- a/src/sestest/FindCertificateCommand.cs
+++ b/src/sestest/FindCertificateCommand.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// Functionality for the <c>find-certificate</c> command
+    /// </summary>
+    public class FindCertificateCommand : CommandBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FindCertificateCommand"/> class
+        /// </summary>
+        /// <param name="logger">A logger to use while executing.</param>
+        public FindCertificateCommand(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        /// Find a certificate
+        /// </summary>
+        /// <param name="commandLine">Configuration from the command line.</param>
+        /// <returns>Results of execution (0 = success).</returns>
+        public int Execute(FindCertificateCommandLine commandLine)
+        {
+            var thumbprint = new CertificateThumbprint(commandLine.Thumbprint);
+            var certificateStore = new CertificateStore();
+            var certificate = certificateStore.FindByThumbprint("required", thumbprint);
+            return certificate.Match(ShowCertificate, LogErrors);
+        }
+
+        private int ShowCertificate(X509Certificate2 certificate)
+        {
+            foreach (var line in certificate.ToString().AsLines())
+            {
+                Logger.LogInformation(line);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/sestest/GenerateCommand.cs
+++ b/src/sestest/GenerateCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
@@ -39,14 +40,15 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             if (!result.HasValue)
             {
-                return LogErrors(result.Errors);
+                Logger.LogErrors(result.Errors);
+                return ResultCodes.Failed;
             }
 
             var token = result.Value;
             if (string.IsNullOrEmpty(commandLine.TokenFile))
             {
                 Logger.LogInformation("Token: {JWT}", token);
-                return 0;
+                return ResultCodes.Success;
             }
 
             var fileInfo = new FileInfo(commandLine.TokenFile);
@@ -54,12 +56,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             try
             {
                 File.WriteAllText(fileInfo.FullName, token);
-                return 0;
+                return ResultCodes.Success;
             }
             catch (Exception ex)
             {
                 Logger.LogError(0, ex, ex.Message);
-                return -1;
+                return ResultCodes.InternalError;
             }
         }
 

--- a/src/sestest/GenerateCommand.cs
+++ b/src/sestest/GenerateCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var signingCert = FindCertificate("signing", commandLine.SignatureThumbprint);
             var encryptionCert = FindCertificate("encryption", commandLine.EncryptionThumbprint);
 
-            var result = entitlement.And(signingCert).And(encryptionCert)
+            Errorable<string> result = entitlement.With(signingCert).With(encryptionCert)
                 .Map(GenerateToken);
 
             if (!result.HasValue)

--- a/src/sestest/GenerateCommand.cs
+++ b/src/sestest/GenerateCommand.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// Functionality for the <c>generate</c> command
+    /// </summary>
+    public sealed class GenerateCommand : CommandBase
+    {
+        // Store used to scan for and obtain certificates
+        private static readonly CertificateStore CertificateStore = new CertificateStore();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenerateCommand"/> class
+        /// </summary>
+        /// <param name="logger">A logger to use while executing.</param>
+        public GenerateCommand(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        /// Generate a new token
+        /// </summary>
+        /// <param name="commandLine">Configuration from the command line.</param>
+        /// <returns>Results of execution (0 = success).</returns>
+        public int Execute(GenerateCommandLine commandLine)
+        {
+            var entitlement = NodeEntitlementsBuilder.Build(commandLine);
+            var signingCert = FindCertificate("signing", commandLine.SignatureThumbprint);
+            var encryptionCert = FindCertificate("encryption", commandLine.EncryptionThumbprint);
+
+            var result = entitlement.And(signingCert).And(encryptionCert)
+                .Map(GenerateToken);
+
+            if (!result.HasValue)
+            {
+                return LogErrors(result.Errors);
+            }
+
+            var token = result.Value;
+            if (string.IsNullOrEmpty(commandLine.TokenFile))
+            {
+                Logger.LogInformation("Token: {JWT}", token);
+                return 0;
+            }
+
+            var fileInfo = new FileInfo(commandLine.TokenFile);
+            Logger.LogInformation("Token file: {FileName}", fileInfo.FullName);
+            try
+            {
+                File.WriteAllText(fileInfo.FullName, token);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(0, ex, ex.Message);
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Generate a token
+        /// </summary>
+        /// <param name="entitlements">Details of the entitlements to encode into the token.</param>
+        /// <param name="signingCert">Certificate to use when signing the token (optional).</param>
+        /// <param name="encryptionCert">Certificate to use when encrypting the token (optional).</param>
+        /// <returns>Generated token, if any; otherwise all related errors.</returns>
+        private string GenerateToken(
+            NodeEntitlements entitlements,
+            X509Certificate2 signingCert = null,
+            X509Certificate2 encryptionCert = null)
+        {
+            SigningCredentials signingCredentials = null;
+            if (signingCert != null)
+            {
+                var signingKey = new X509SecurityKey(signingCert);
+                signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha512Signature);
+            }
+
+            EncryptingCredentials encryptingCredentials = null;
+            if (encryptionCert != null)
+            {
+                var encryptionKey = new X509SecurityKey(encryptionCert);
+                encryptingCredentials = new EncryptingCredentials(
+                    encryptionKey, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes256CbcHmacSha512);
+            }
+
+            var entitlementWithIdentifier = entitlements.WithIdentifier($"entitlement-{Guid.NewGuid():D}");
+
+            var generator = new TokenGenerator(Logger, signingCredentials, encryptingCredentials);
+            return generator.Generate(entitlementWithIdentifier);
+        }
+
+        private static Errorable<X509Certificate2> FindCertificate(string purpose, string thumbprint)
+        {
+            if (string.IsNullOrEmpty(thumbprint))
+            {
+                // No certificate requested, so we successfully return null
+                return Errorable.Success<X509Certificate2>(null);
+            }
+
+            var t = new CertificateThumbprint(thumbprint);
+            return CertificateStore.FindByThumbprint(purpose, t);
+        }
+    }
+}

--- a/src/sestest/GenerateCommand.cs
+++ b/src/sestest/GenerateCommand.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Results of execution (0 = success).</returns>
         public int Execute(GenerateCommandLine commandLine)
         {
-            var entitlement = NodeEntitlementsBuilder.Build(commandLine);
-            var signingCert = FindCertificate("signing", commandLine.SignatureThumbprint);
-            var encryptionCert = FindCertificate("encryption", commandLine.EncryptionThumbprint);
+            Errorable<NodeEntitlements> entitlement = NodeEntitlementsBuilder.Build(commandLine);
+            Errorable<X509Certificate2> signingCert = FindCertificate("signing", commandLine.SignatureThumbprint);
+            Errorable<X509Certificate2> encryptionCert = FindCertificate("encryption", commandLine.EncryptionThumbprint);
 
             Errorable<string> result = entitlement.With(signingCert).With(encryptionCert)
                 .Map(GenerateToken);

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// </summary>
         /// <param name="commandLine">Configuration from the command line.</param>
         /// <returns>Results of execution (0 = success).</returns>
-        public int Execute(ListCertificatesCommandLine commandLine)
+        public Task<int> Execute(ListCertificatesCommandLine commandLine)
         {
             var now = DateTime.Now;
 
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             Logger.LogInformationTable(rows);
 
-            return 0;
+            return Task.FromResult(0);
         }
 
         private static IList<string> DescribeCertificate(X509Certificate2 cert)

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -44,9 +44,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var rows = query.Select(DescribeCertificate).ToList();
             rows.Insert(0, new List<string> { "Name", "Friendly Name", "Thumbprint", "Not Before", "Not After" });
 
-            Logger.LogTable(
-                LogLevel.Information,
-                rows);
+            Logger.LogInformationTable(rows);
 
             return 0;
         }

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// Functionality for the <c>list-certificates</c> command
+    /// </summary>
+    public class ListCertificatesCommand : CommandBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListCertificatesCommand"/> class
+        /// </summary>
+        /// <param name="logger">A logger to use while executing.</param>
+        public ListCertificatesCommand(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        /// List available certificates
+        /// </summary>
+        /// <param name="commandLine">Configuration from the command line.</param>
+        /// <returns>Results of execution (0 = success).</returns>
+        public int Execute(ListCertificatesCommandLine commandLine)
+        {
+            var now = DateTime.Now;
+
+            if (commandLine.ShowExpired)
+            {
+                Logger.LogInformation("Including expired certificates.");
+            }
+
+            var certificateStore = new CertificateStore();
+            var allCertificates = certificateStore.FindAll();
+            var query = allCertificates.Where(c => c.HasPrivateKey)
+                .Where(c => now < c.NotAfter || commandLine.ShowExpired)
+                .ToList();
+            Logger.LogInformation("Found {Count} certificates with private keys", query.Count);
+
+            var rows = query.Select(DescribeCertificate).ToList();
+            rows.Insert(0, new List<string> { "Name", "Friendly Name", "Thumbprint", "Not Before", "Not After" });
+
+            Logger.LogTable(
+                LogLevel.Information,
+                rows);
+
+            return 0;
+        }
+
+        private static IList<string> DescribeCertificate(X509Certificate2 cert)
+        {
+            var status = string.Empty;
+            if (cert.NotAfter < DateTime.Now)
+            {
+                status = "(expired)";
+            }
+            else if (DateTime.Now < cert.NotBefore)
+            {
+                status = "(not yet active)";
+            }
+
+            const string format = "HH:mm dd/mmm/yyyy";
+
+            return new List<string>
+            {
+                cert.SubjectName.Name,
+                cert.FriendlyName,
+                cert.Thumbprint,
+                cert.NotBefore.ToString(format),
+                cert.NotAfter.ToString(format),
+                status
+            };
+        }
+    }
+}

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -62,15 +62,15 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 status = "(not yet active)";
             }
 
-            const string format = "HH:mm dd/mmm/yyyy";
+            const string dateFormat = "s";
 
             return new List<string>
             {
                 cert.SubjectName.Name,
                 cert.FriendlyName,
                 cert.Thumbprint,
-                cert.NotBefore.ToString(format),
-                cert.NotAfter.ToString(format),
+                cert.NotBefore.ToString(dateFormat),
+                cert.NotAfter.ToString(dateFormat),
                 status
             };
         }

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -2,12 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using CommandLine;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {
@@ -60,7 +57,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var command = new GenerateCommand(_logger);
             return command.Execute(commandLine);
         }
-        
+
         /// <summary>
         /// Serve mode - run as a standalone web server
         /// </summary>
@@ -109,12 +106,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             var logSetup = new LoggerSetup();
 
-            var consoleLevel = TryParse(commandLine.LogLevel, "console", LogLevel.Information);
+            var consoleLevel = TryParseLogLevel(commandLine.LogLevel, "console", LogLevel.Information);
             var actualLevel = consoleLevel.HasValue ? consoleLevel.Value : LogLevel.Information;
 
             logSetup.SendToConsole(actualLevel);
 
-            var fileLevel = TryParse(commandLine.LogFileLevel, "file", actualLevel);
+            var fileLevel = TryParseLogLevel(commandLine.LogFileLevel, "file", actualLevel);
             if (!string.IsNullOrEmpty(commandLine.LogFile))
             {
                 if (fileLevel.HasValue)
@@ -179,7 +176,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             return -1;
         }
 
-        private static Errorable<LogLevel> TryParse(string level, string purpose, LogLevel defaultLevel)
+        private static Errorable<LogLevel> TryParseLogLevel(string level, string purpose, LogLevel defaultLevel)
         {
             if (string.IsNullOrEmpty(level))
             {

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -163,20 +163,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Exit code for process.</returns>
         private static int FindCertificate(FindCertificateCommandLine commandLine)
         {
-            var thumbprint = new CertificateThumbprint(commandLine.Thumbprint);
-            var certificateStore = new CertificateStore();
-            var certificate = certificateStore.FindByThumbprint("required", thumbprint);
-            return certificate.Match(ShowCertificate, LogErrors);
-        }
-
-        private static int ShowCertificate(X509Certificate2 certificate)
-        {
-            foreach (var line in certificate.ToString().AsLines())
-            {
-                _logger.LogInformation(line);
-            }
-
-            return 0;
+            var command = new FindCertificateCommand(_logger);
+            return command.Execute(commandLine);
         }
 
         /// <summary>

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var parser = new Parser(ConfigureParser);
 
             var parseResult = parser
-                .ParseArguments<GenerateCommandLine, ServerCommandLine, ListCertificatesCommandLine, FindCertificateCommandLine>(args);
+                .ParseArguments<GenerateCommandLine, ServerCommandLine, ListCertificatesCommandLine, FindCertificateCommandLine, VerifyCommandLine>(args);
 
             parseResult.WithParsed((CommandLineBase options) => ConfigureLogging(options));
 
@@ -36,7 +36,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                     (ServerCommandLine commandLine) => RunCommand(Serve, commandLine),
                     (ListCertificatesCommandLine commandLine) => RunCommand(ListCertificates, commandLine),
                     (FindCertificateCommandLine commandLine) => RunCommand(FindCertificate, commandLine),
-                    errors => 1);
+                    (VerifyCommandLine commandLine) => RunCommand(Submit, commandLine),
+                    errors => Task.FromResult(-1));
 
                 if (Debugger.IsAttached)
                 {
@@ -96,6 +97,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         private static async Task<int> FindCertificate(FindCertificateCommandLine commandLine)
         {
             var command = new FindCertificateCommand(_logger);
+            return await command.Execute(commandLine).ConfigureAwait(false);
+        }
+
+        private static async Task<int> Submit(VerifyCommandLine commandLine)
+        {
+            var command = new VerifyCommand(_logger);
             return await command.Execute(commandLine).ConfigureAwait(false);
         }
 

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             var server = new SoftwareEntitlementServer(options, _provider);
             server.Run();
-            return 0;
+            return Task.FromResult(ResultCodes.Success);
         }
 
         /// <summary>

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -152,53 +152,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Exit code for process.</returns>
         private static int ListCertificates(ListCertificatesCommandLine commandLine)
         {
-            var now = DateTime.Now;
-
-            if (commandLine.ShowExpired)
-            {
-                _logger.LogInformation("Including expired certificates.");
-            }
-
-            var certificateStore = new CertificateStore();
-            var allCertificates = certificateStore.FindAll();
-            var query = allCertificates.Where(c => c.HasPrivateKey)
-                .Where(c => now < c.NotAfter  || commandLine.ShowExpired)
-                .ToList();
-            _logger.LogInformation("Found {Count} certificates with private keys", query.Count);
-
-            var rows = query.Select(DescribeCertificate).ToList();
-            rows.Insert(0, new List<string> { "Name", "Friendly Name", "Thumbprint", "Not Before", "Not After" });
-
-            _logger.LogTable(
-                LogLevel.Information,
-                rows);
-
-            return 0;
-        }
-
-        private static IList<string> DescribeCertificate(X509Certificate2 cert)
-        {
-            var status = string.Empty;
-            if (cert.NotAfter < DateTime.Now)
-            {
-                status = "(expired)";
-            }
-            else if (DateTime.Now < cert.NotBefore)
-            {
-                status = "(not yet active)";
-            }
-
-            const string format = "HH:mm dd/mmm/yyyy";
-
-            return new List<string>
-            {
-                cert.SubjectName.Name,
-                cert.FriendlyName,
-                cert.Thumbprint,
-                cert.NotBefore.ToString(format),
-                cert.NotAfter.ToString(format),
-                status
-            };
+            var command = new ListCertificatesCommand(_logger);
+            return command.Execute(commandLine);
         }
 
         /// <summary>

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             parseResult.WithParsed((CommandLineBase options) => ConfigureLogging(options));
 
-            var exitCode = -1;
+            var exitCode = ResultCodes.Failed;
             if (_logger != null)
             {
                 // Logging is ready for use, can try other things
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                     (ListCertificatesCommandLine commandLine) => RunCommand(ListCertificates, commandLine),
                     (FindCertificateCommandLine commandLine) => RunCommand(FindCertificate, commandLine),
                     (VerifyCommandLine commandLine) => RunCommand(Submit, commandLine),
-                    errors => Task.FromResult(-1));
+                    errors => Task.FromResult(ResultCodes.Failed));
 
                 if (Debugger.IsAttached)
                 {
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             catch (Exception ex)
             {
                 _logger.LogError(0, ex, ex.Message);
-                return -1;
+                return ResultCodes.InternalError;
             }
         }
 

--- a/src/sestest/ResultCodes.cs
+++ b/src/sestest/ResultCodes.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    public static class ResultCodes
+    {
+        /// <summary>
+        /// Result code for successful execution
+        /// </summary>
+        public static readonly int Success = 0;
+
+        /// <summary>
+        /// Result code for failed execution
+        /// </summary>
+        public static readonly int Failed = -1;
+
+        /// <summary>
+        /// Result code for an internal error (typically an exception)
+        /// </summary>
+        public static readonly int InternalError = -1000;
+    }
+}

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -67,13 +67,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
         }
 
-        private int LogResult(string response)
-        {
-            var pretty = JsonPrettify(response).AsLines();
-            Logger.LogInformation(pretty);
-            return 0;
-        }
-
         private Errorable<string> FindToken(VerifyCommandLine commandLine)
         {
             var token = commandLine.Token;
@@ -157,28 +150,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             return query.ToString();
-        }
-
-        /// <summary>
-        /// Pretty print a JSON string for logging
-        /// </summary>
-        /// <remarks>
-        /// As found on StackOverflow: https://stackoverflow.com/a/30329731/30280
-        /// </remarks>
-        /// <param name="json">JSON string to reformat.</param>
-        /// <returns>Equivalent JSON with nice formatting.</returns>
-        private static string JsonPrettify(string json)
-        {
-            using (var stringReader = new StringReader(json))
-            {
-                using (var stringWriter = new StringWriter())
-                {
-                    var jsonReader = new JsonTextReader(stringReader);
-                    var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.Indented };
-                    jsonWriter.WriteToken(jsonReader);
-                    return stringWriter.ToString();
-                }
-            }
         }
     }
 }

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -30,10 +30,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Results of execution (0 = success).</returns>
         public async Task<int> Execute(VerifyCommandLine commandLine)
         {
-            var server = FindServer(commandLine);
-            var token = FindToken(commandLine);
-            var app = FindApplication(commandLine);
-            var api = FindApiVersion(commandLine);
+            Errorable<Uri> server = FindServer(commandLine);
+            Errorable<string> token = FindToken(commandLine);
+            Errorable<string> app = FindApplication(commandLine);
+            Errorable<string> api = FindApiVersion(commandLine);
 
             Errorable<string> result = await server.With(token).With(app).With(api)
                 .MapAsync(SubmitToken);

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// Functionality for the <c>submit</c> command
+    /// </summary>
+    public sealed class VerifyCommand : CommandBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VerifyCommand"/> class
+        /// </summary>
+        /// <param name="logger">A logger to use while executing.</param>
+        public VerifyCommand(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        /// Generate a new token
+        /// </summary>
+        /// <param name="commandLine">Configuration from the command line.</param>
+        /// <returns>Results of execution (0 = success).</returns>
+        public async Task<int> Execute(VerifyCommandLine commandLine)
+        {
+            var server = FindServer(commandLine);
+            var token = FindToken(commandLine);
+            var app = FindApplication(commandLine);
+            var api = FindApiVersion(commandLine);
+
+            var result = await server.And(token).And(app).And(api)
+                .MapAsync(SubmitToken);
+            return result.Match(LogResult, LogErrors);
+        }
+
+        private async Task<string> SubmitToken(Uri server, string token, string app, string api)
+        {
+            var builder = new UriBuilder(server);
+            //TODO: Do this in a path safe way similar to Path.Combine
+            builder.Path = builder.Path + "softwareEntitlements";
+            builder.Query = CreateParameters(("api-version", api));
+
+            var uri = builder.Uri;
+
+            using (var client = new HttpClient())
+            {
+                var request = new SoftwareEntitlementRequest
+                {
+                    Token = token,
+                    ApplicationId = app
+                };
+
+                var requestJson = JsonConvert.SerializeObject(request);
+                var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+
+                var result = await client.PostAsync(uri, content).ConfigureAwait(false);
+                Logger.LogInformation($"Status Code: {result.StatusCode} ({(int) result.StatusCode})");
+
+                return await result.Content.ReadAsStringAsync();
+            }
+        }
+
+        private int LogResult(string response)
+        {
+            var pretty = JsonPrettify(response).AsLines();
+            Logger.LogInformation(pretty);
+            return 0;
+        }
+
+        private Errorable<string> FindToken(VerifyCommandLine commandLine)
+        {
+            var token = commandLine.Token;
+            if (string.IsNullOrEmpty(token))
+            {
+                token = ReadEnvironmentVariable("AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN");
+            }
+
+            if (string.IsNullOrEmpty(token))
+            {
+                return Errorable.Failure<string>(
+                    "No token supplied on command line and AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN not set.");
+            }
+
+            return Errorable.Success(token);
+        }
+
+        private Errorable<string> FindApplication(VerifyCommandLine commandLine)
+        {
+            var application = commandLine.Application;
+            if (string.IsNullOrEmpty(application))
+            {
+                return Errorable.Failure<string>("No application specified.");
+            }
+
+            return Errorable.Success(application);
+        }
+
+        private Errorable<Uri> FindServer(VerifyCommandLine commandLine)
+        {
+            var server = commandLine.Server;
+            if (string.IsNullOrEmpty(server))
+            {
+                server = ReadEnvironmentVariable("AZ_BATCH_ACCOUNT_URL");
+            }
+
+            if (string.IsNullOrEmpty(server))
+            {
+                return Errorable.Failure<Uri>("No server supplied on command line and AZ_BATCH_ACCOUNT_URL not set.");
+            }
+
+            try
+            {
+                return Errorable.Success(new Uri(commandLine.Server));
+            }
+            catch (UriFormatException ex)
+            {
+                return Errorable.Failure<Uri>(
+                    $"Failed to parse server url ({ex.Message})");
+            }
+        }
+
+        private Errorable<string> FindApiVersion(VerifyCommandLine commandLine)
+        {
+            var version = commandLine.ApiVersion;
+            if (string.IsNullOrEmpty(version))
+            {
+                version = "2017-05-01.5.0";
+            }
+
+            return Errorable.Success(version);
+        }
+
+        private string ReadEnvironmentVariable(string name)
+        {
+            var result = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrEmpty(result))
+            {
+                Logger.LogInformation("Using environment variable " + name);
+            }
+
+            return result;
+        }
+
+        private string CreateParameters(params (string name, string value)[] parameters)
+        {
+            var query = HttpUtility.ParseQueryString(string.Empty);
+            foreach (var p in parameters)
+            {
+                query[p.name] = p.value;
+            }
+
+            return query.ToString();
+        }
+
+        /// <summary>
+        /// Pretty print a JSON string for logging
+        /// </summary>
+        /// <remarks>
+        /// As found on StackOverflow: https://stackoverflow.com/a/30329731/30280
+        /// </remarks>
+        /// <param name="json">JSON string to reformat.</param>
+        /// <returns>Equivalent JSON with nice formatting.</returns>
+        private static string JsonPrettify(string json)
+        {
+            using (var stringReader = new StringReader(json))
+            {
+                using (var stringWriter = new StringWriter())
+                {
+                    var jsonReader = new JsonTextReader(stringReader);
+                    var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.Indented };
+                    jsonWriter.WriteToken(jsonReader);
+                    return stringWriter.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var app = FindApplication(commandLine);
             var api = FindApiVersion(commandLine);
 
-            var result = await server.And(token).And(app).And(api)
+            Errorable<string> result = await server.With(token).With(app).With(api)
                 .MapAsync(SubmitToken);
             return result.Match(LogResult, LogErrors);
         }

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -37,7 +37,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             Errorable<string> result = await server.With(token).With(app).With(api)
                 .MapAsync(SubmitToken);
-            return result.Match(LogResult, LogErrors);
+            return result.Match(response =>
+                {
+                    Logger.LogJson(response);
+                    return ResultCodes.Success;
+                },
+                errors =>
+                {
+                    Logger.LogErrors(errors);
+                    return ResultCodes.Failed;
+                });
         }
 
         private async Task<string> SubmitToken(Uri server, string token, string app, string api)

--- a/src/sestest/VerifyCommandLine.cs
+++ b/src/sestest/VerifyCommandLine.cs
@@ -1,27 +1,23 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {
-    [Verb("verify", HelpText = "Verify a provided token by calling into the software entitlement service.")]
+    [Verb("verify", HelpText = "Submit a token for verification")]
     public sealed class VerifyCommandLine : CommandLineBase
     {
-        [Option("token", HelpText = "The text of the JWT token to verify.")]
+        [Option("token",
+            HelpText = "Software entitlement token to verify (defaults to the environment variable AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN)")]
         public string Token { get; set; }
 
-        [Option("token-file", HelpText = "A text file containing the text of the JWT token to verify.")]
-        public string TokenFile { get; set; }
+        [Option("app", HelpText = "The application for which entitlement is requested.")]
+        public string Application { get; set; }
 
-        [Option("entitlement-id", HelpText = "Unique identifier for the entitlement to check.")]
-        public string ApplicationId { get; set; }
+        [Option("server",
+            HelpText = "URL for the software entitlement server (defaults to the environment variable AZ_BATCH_ACCOUNT_URL)")]
+        public string Server { get; set; }
 
-        [Option("vmid", HelpText = "Unique identifier for the Azure virtual machine.")]
-        public string VirtualMachineId { get; set; }
-
-        [Option("batch-service-url", HelpText = "URL of the Azure Batch service endpoint for a particular account to contact for verification.")]
-        public string BatchServiceUrl { get; set; }
-
-        // TODO: This needs a much better name
-        [Option('a', "authority", HelpText = "Certificate thumbprint used to sign the cert used for the HTTPS connection.")]
-        public string AuthorityThumbprint { get; set; }
+        [Option("api-version",
+            HelpText = "API version to specify when making the request (defaults to '2017-05-01.5.0')")]
+        public string ApiVersion { get; set; } = "2017-05-01.5.0";
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/ErrorableExtensionTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/ErrorableExtensionTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
     /// </summary>
     public abstract class ErrorableExtensionTests
     {
-        // Known errorable values for testing
+        // Known Errorable<T> values for testing
         private readonly Errorable<int> _missingInt = null;
         private readonly Errorable<string> _missingString = null;
         private readonly Errorable<int> _success = Errorable.Success(4);
@@ -21,14 +21,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
         private readonly Errorable<int> _yetAnotherSuccess = Errorable.Success(8);
         private readonly Errorable<int> _yetAnotherFailure = Errorable.Failure<int>("yet another failure");
 
-        public class AndReturningTuple : ErrorableExtensionTests
+        public class WithReturningTuple : ErrorableExtensionTests
         {
             [Fact]
             public void GivenNullOnLeft_ThrowsExpectedException()
             {
                 var exception =
                     Assert.Throws<ArgumentNullException>(
-                        () => _missingInt.And(_success));
+                        () => _missingInt.With(_success));
                 exception.Should().NotBeNull();
                 exception.ParamName.Should().Be("left");
             }
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             {
                 var exception =
                     Assert.Throws<ArgumentNullException>(
-                        () => _success.And(_missingInt));
+                        () => _success.With(_missingInt));
                 exception.Should().NotBeNull();
                 exception.ParamName.Should().Be("right");
             }
@@ -46,21 +46,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             [Fact]
             public void GivenFailureOnLeft_ReturnsFailureWithSameErrors()
             {
-                var result = _failure.And(_success);
+                var result = _failure.With(_success);
                 result.Errors.Should().Contain(_failure.Errors);
             }
 
             [Fact]
             public void GivenFailureOnRight_ReturnsFailureWithSameErrors()
             {
-                var result = _success.And(_failure);
+                var result = _success.With(_failure);
                 result.Errors.Should().Contain(_failure.Errors);
             }
 
             [Fact]
             public void GivenFailureOnBothSides_ReturnsFailureWithAllErrors()
             {
-                var result = _failure.And(_otherFailure);
+                var result = _failure.With(_otherFailure);
                 result.Errors.Should().Contain(_failure.Errors);
                 result.Errors.Should().Contain(_otherFailure.Errors);
             }
@@ -68,62 +68,62 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             [Fact]
             public void GivenSuccessOnBothSides_ReturnsExpectedTuple()
             {
-                var result = _success.And(_otherSuccess);
+                var result = _success.With(_otherSuccess);
                 result.Value.Should().Be((_success.Value, _otherSuccess.Value));
             }
         }
 
 
-        public class AndWithTupleOnLeftReturningTriple : ErrorableExtensionTests
+        public class WithHavingTupleOnLeftReturningTriple : ErrorableExtensionTests
         {
             [Fact]
             public void GivenSuccessOnBothSides_ReturnsExpectedTuple()
             {
-                var left = _success.And(_otherSuccess);
-                var result = left.And(_yetAnotherSuccess);
+                var left = _success.With(_otherSuccess);
+                var result = left.With(_yetAnotherSuccess);
                 result.Value.Should().Be((_success.Value, _otherSuccess.Value, _yetAnotherSuccess.Value));
             }
 
             [Fact]
             public void WhenFailureOnLeft_ReturnsExpectedErrors()
             {
-                var left = _failure.And(_otherSuccess);
-                var result = left.And(_yetAnotherSuccess);
+                var left = _failure.With(_otherSuccess);
+                var result = left.With(_yetAnotherSuccess);
                 result.Errors.Should().Contain(_failure.Errors);
             }
 
             [Fact]
             public void WhenFailureOnRight_ReturnsExpectedErrors()
             {
-                var left = _success.And(_otherSuccess);
-                var result = left.And(_yetAnotherFailure);
+                var left = _success.With(_otherSuccess);
+                var result = left.With(_yetAnotherFailure);
                 result.Errors.Should().Contain(_yetAnotherFailure.Errors);
             }
         }
 
-        public class AndWithTupleOnRightReturningTriple : ErrorableExtensionTests
+        public class WithHavingTupleOnRightReturningTriple : ErrorableExtensionTests
         {
             [Fact]
             public void GivenTupleOnRight_ReturnsExpectedValue()
             {
-                var right = _otherSuccess.And(_yetAnotherSuccess);
-                var result = _success.And(right);
+                var right = _otherSuccess.With(_yetAnotherSuccess);
+                var result = _success.With(right);
                 result.Value.Should().Be((_success.Value, _otherSuccess.Value, _yetAnotherSuccess.Value));
             }
 
             [Fact]
             public void WhenFailureOnLeft_ReturnsExpectedErrors()
             {
-                var right = _otherSuccess.And(_yetAnotherSuccess);
-                var result = _failure.And(right);
+                var right = _otherSuccess.With(_yetAnotherSuccess);
+                var result = _failure.With(right);
                 result.Errors.Should().Contain(_failure.Errors);
             }
 
             [Fact]
             public void WhenFailureOnRight_ReturnsExpectedErrors()
             {
-                var right = _otherSuccess.And(_yetAnotherFailure);
-                var result = _success.And(right);
+                var right = _otherSuccess.With(_yetAnotherFailure);
+                var result = _success.With(right);
                 result.Errors.Should().Contain(_yetAnotherFailure.Errors);
             }
         }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/LoggerExtensionsTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/LoggerExtensionsTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using FluentAssertions;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.Fakes;
 using Microsoft.Extensions.Logging;
@@ -25,7 +23,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
                     new List<string> { "gamma" },
                     new List<string> { "delta" }
                 };
-                _logger.LogTable(LogLevel.Information, lines);
+                _logger.LogInformationTable(lines);
                 _logger.Events.Should().HaveCount(4);
                 _logger.Events.Should().OnlyContain(e => e.Level == LogLevel.Information);
                 _logger.Events.Select(e => e.Message).Should().ContainInOrder("alpha", "beta", "gamma", "delta");
@@ -45,7 +43,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
                     new List<string> { "phi", "Uranus" },
                     new List<string> { "omicron", "Neptune" }
                 };
-                _logger.LogTable(LogLevel.Information, lines);
+                _logger.LogInformationTable(lines);
                 _logger.Events.Should().HaveCount(8);
                 _logger.Events.Should().OnlyContain(e => e.Level == LogLevel.Information);
                 _logger.Events.Select(e => e.Message).Should().ContainInOrder(
@@ -73,7 +71,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
                     new List<string> { "phi", "Uranus" },
                     new List<string> { "omicron", "Neptune" }
                 };
-                _logger.LogTable(LogLevel.Information, lines);
+                _logger.LogInformationTable(lines);
                 _logger.Events.Should().HaveCount(8);
                 _logger.Events.Should().OnlyContain(e => e.Level == LogLevel.Information);
                 _logger.Events.Select(e => e.Message).Should().ContainInOrder(


### PR DESCRIPTION
Update the software entitlements SDK to support the next API version of software entitlements (deprecating `vmid` and introducing `expiry` on the server response). 

This PR includes
* API support for the `sestest server`
* New mode `sestest verify` allowing for testing across api versions
* Refactoring of `sestest` to improve maintainability of code

The actual `api-version` is still to be decided, so this will need changing. Changes to `sesclient` will be in a future PR.