### PR TITLE
WIP: v2 changes - max CPU core count and host ID

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Controllers/SoftwareEntitlementsController.cs
@@ -138,6 +138,28 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
 
             var request = new EntitlementVerificationRequest(requestBody.ApplicationId, remoteAddress);
 
+            if (ApiRequiresHostId(apiVersion))
+            {
+                if (requestBody.HostId == null)
+                {
+                    return Errorable.Failure<(EntitlementVerificationRequest, string)>(
+                        "Missing hostId value from software entitlement request.");
+                }
+
+                request.HostId = requestBody.HostId;
+            }
+
+            if (ApiRequiresCpuCoreCount(apiVersion))
+            {
+                if (!requestBody.Cores.HasValue)
+                {
+                    return Errorable.Failure<(EntitlementVerificationRequest, string)>(
+                        "Missing cores value from software entitlement request.");
+                }
+
+                request.CpuCoreCount = requestBody.Cores;
+            }
+
             return Errorable.Success((Request: request, Token: requestBody.Token));
         }
 
@@ -215,6 +237,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server.Controllers
 
             return apiVersion.Equals(ApiVersion201705, StringComparison.Ordinal)
                    || apiVersion.Equals(ApiVersion201709, StringComparison.Ordinal);
+        }
+
+        private static bool ApiRequiresHostId(string apiVersion)
+        {
+            return string.Equals(apiVersion, ApiVersion201709, StringComparison.Ordinal);
+        }
+
+        private static bool ApiRequiresCpuCoreCount(string apiVersion)
+        {
+            return string.Equals(apiVersion, ApiVersion201709, StringComparison.Ordinal);
         }
 
         private static bool ApiSupportsVirtualMachineId(string apiVersion)

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/SoftwareEntitlementRequestBody.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/SoftwareEntitlementRequestBody.cs
@@ -15,5 +15,15 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server
         /// Unique identifier for the application for which an entitlement is sought
         /// </summary>
         public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// A unique identifier for the host machine
+        /// </summary>
+        public string HostId { get; set; }
+
+        /// <summary>
+        /// The number of CPU cores claimed to be on the host machine, or null if no value was supplied
+        /// </summary>
+        public int? Cores { get; set; }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Startup.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Server
                     serverOptions.SigningKey,
                     serverOptions.EncryptionKey);
             });
+            services.TryAddSingleton<IHostVerifier, StoredEntitlementHostVerifier>();
             services.TryAddSingleton<EntitlementVerifier>();
         }
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Claims.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Claims.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Azure.Batch.SoftwareEntitlement
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {
     /// <summary>
     /// Values used to define the claims used in our software entitlement token
@@ -36,5 +36,31 @@
         /// Identifier use for the claim specifying the permitted virtual machine
         /// </summary>
         public const string VirtualMachineId = "vmid";
+
+        /// <summary>
+        /// The identifier to use for the maximum expected number of CPU cores permitted on the
+        /// virtual machine
+        /// </summary>
+        public const string CpuCoreCount = "maxcores";
+
+        /// <summary>
+        /// The unique identifier of the batch account that owns the pool
+        /// </summary>
+        public const string BatchAccountId = "batchaccount";
+
+        /// <summary>
+        /// The unique identifier for the pool on which the application is expected to be running
+        /// </summary>
+        public const string PoolId = "poolid";
+
+        /// <summary>
+        /// A unique identifier for the job within which the task is running
+        /// </summary>
+        public const string JobId = "jobid";
+
+        /// <summary>
+        /// A unique identifier for the task itself
+        /// </summary>
+        public const string TaskId = "taskid";
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/EntitlementVerificationRequest.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/EntitlementVerificationRequest.cs
@@ -32,5 +32,17 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// Address of the machine requesting token validation
         /// </summary>
         public IPAddress IpAddress { get; }
+
+        /// <summary>
+        /// The number of CPU cores reported to be found by the application,
+        /// or null if that doesn't need to be verified
+        /// </summary>
+        public int? CpuCoreCount { get; set; }
+
+        /// <summary>
+        /// A unique identifier for the host machine, or null if that doesn't
+        /// need to be verified
+        /// </summary>
+        public string HostId { get; set; }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/EntitlementVerifier.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/EntitlementVerifier.cs
@@ -10,14 +10,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
     public class EntitlementVerifier
     {
         private readonly IEntitlementParser _entitlementParser;
+        private readonly IHostVerifier _hostVerifier;
 
         /// <summary>
         /// Constructs a new <see cref="EntitlementVerifier"/>
         /// </summary>
-        /// <param name="tokenParser">Extracts identity information from a string token</param>
-        public EntitlementVerifier(IEntitlementParser entitlementParser)
+        /// <param name="entitlementParser">Extracts identity information from a string token</param>
+        /// <param name="hostVerifier">Verifies whether a host is permitted for a given entitlement</param>
+        public EntitlementVerifier(
+		    IEntitlementParser entitlementParser,
+            IHostVerifier hostVerifier)
         {
             _entitlementParser = entitlementParser ?? throw new ArgumentNullException(nameof(entitlementParser));
+            _hostVerifier = hostVerifier ?? throw new ArgumentNullException(nameof(hostVerifier));
         }
 
         /// <summary>
@@ -42,7 +47,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 .Bind(e => Verify(request, e));
         }
 
-        private static Errorable<NodeEntitlements> Verify(
+        private Errorable<NodeEntitlements> Verify(
             EntitlementVerificationRequest request,
             NodeEntitlements entitlement)
         {
@@ -54,6 +59,33 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             if (!entitlement.IpAddresses.Any(addr => addr.Equals(request.IpAddress)))
             {
                 return Errorable.Failure<NodeEntitlements>($"Token does not grant entitlement for {request.IpAddress}");
+            }
+
+            // There should always be a CPU core count in the token, even though the
+            // particular version of the API we're using may not require it to be
+            // checked.
+            if (!entitlement.CpuCoreCount.HasValue)
+            {
+                return Errorable.Failure<NodeEntitlements>("Token does not grant entitlement for any CPU cores");
+            }
+
+            // The presence of a CPU core count in the request indicates that we need to validate
+            // it against the maximum permitted number in the entitlement.
+            // Checking whether we're *supposed* to have a value provided in the request is
+            // beyond the scope of this method.
+            if (request.CpuCoreCount.HasValue &&
+                request.CpuCoreCount.Value > entitlement.CpuCoreCount.Value)
+            {
+                return Errorable.Failure<NodeEntitlements>(
+                    $"Token does not grant entitlement for {request.CpuCoreCount.Value} CPU cores");
+            }
+
+            // The presence of a hostId value in the request indicates that we need to check it.
+            if (request.HostId != null &&
+                !_hostVerifier.Verify(entitlement, request.HostId))
+            {
+                return Errorable.Failure<NodeEntitlements>(
+                    $"Host {request.HostId} is not allowed for entitlement {entitlement.Identifier}");
             }
 
             return Errorable.Success(entitlement);

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/IEntitlementPropertyProvider.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/IEntitlementPropertyProvider.cs
@@ -48,6 +48,31 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         Errorable<IEnumerable<IPAddress>> IpAddresses();
 
         /// <summary>
+        /// Gets the number of CPU cores configured for the selected VM SKU
+        /// </summary>
+        Errorable<int> CpuCoreCount();
+
+        /// <summary>
+        /// The unique identifier of the batch account that owns the pool
+        /// </summary>
+        Errorable<string> BatchAccountId();
+
+        /// <summary>
+        /// The unique identifier for the pool on which the application is expected to be running
+        /// </summary>
+        Errorable<string> PoolId();
+
+        /// <summary>
+        /// A unique identifier for the job within which the task is running
+        /// </summary>
+        Errorable<string> JobId();
+
+        /// <summary>
+        /// A unique identifier for the task itself
+        /// </summary>
+        Errorable<string> TaskId();
+
+        /// <summary>
         /// Gets the virtual machine identifier for the machine entitled to use the specified packages
         /// </summary>
         Errorable<string> VirtualMachineId();

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/IHostVerifier.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/IHostVerifier.cs
@@ -1,0 +1,20 @@
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// A type which can verify whether a given hostId value is valid, given a <see cref="NodeEntitlements"/>
+    /// instance.
+    /// </summary>
+    public interface IHostVerifier
+    {
+        /// <summary>
+        /// Returns a value indicating whether the specified <paramref name="hostId"/> value
+        /// is valid for the <paramref name="entitlement"/>.
+        /// </summary>
+        /// <param name="entitlement">A set of entitlements</param>
+        /// <param name="hostId">An identifier for a host</param>
+        /// <returns>
+        /// True if the <paramref name="hostId"/> is valid, or false otherwise.
+        /// </returns>
+        bool Verify(NodeEntitlements entitlement, string hostId);
+    }
+}

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtEntitlementPropertyProvider.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtEntitlementPropertyProvider.cs
@@ -103,6 +103,46 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             => ReadAll(Claims.IpAddress).Select(ParseIpAddress).Reduce();
 
         /// <summary>
+        /// Gets the number of CPU cores configured for the selected VM SKU
+        /// </summary>
+        public Errorable<int> CpuCoreCount()
+        {
+            var coreCountText = Read(Claims.CpuCoreCount);
+            if (string.IsNullOrEmpty(coreCountText))
+            {
+                return Errorable.Failure<int>("Missing CPU core count in token.");
+            }
+
+            return int.TryParse(coreCountText, out int coreCount)
+                ? Errorable.Success(coreCount)
+                : Errorable.Failure<int>($"Invalid CPU core count value '{coreCountText}'");
+        }
+
+        /// <summary>
+        /// The unique identifier of the batch account that owns the pool
+        /// </summary>
+        public Errorable<string> BatchAccountId()
+            => Errorable.Success(Read(Claims.BatchAccountId));
+
+        /// <summary>
+        /// The unique identifier for the pool on which the application is expected to be running
+        /// </summary>
+        public Errorable<string> PoolId()
+            => Errorable.Success(Read(Claims.PoolId));
+
+        /// <summary>
+        /// A unique identifier for the job within which the task is running
+        /// </summary>
+        public Errorable<string> JobId()
+            => Errorable.Success(Read(Claims.JobId));
+
+        /// <summary>
+        /// A unique identifier for the task itself
+        /// </summary>
+        public Errorable<string> TaskId()
+            => Errorable.Success(Read(Claims.TaskId));
+
+        /// <summary>
         /// Gets the virtual machine identifier for the machine entitled to use the specified packages from a claim
         /// in the principal.
         /// </summary>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
@@ -48,6 +48,31 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         public string Identifier { get; }
 
         /// <summary>
+        /// Gets the number of CPU cores configured for the selected VM SKU
+        /// </summary>
+        public int? CpuCoreCount { get; }
+
+        /// <summary>
+        /// The unique identifier of the batch account that owns the pool
+        /// </summary>
+        public string BatchAccountId { get; }
+
+        /// <summary>
+        /// The unique identifier for the pool on which the application is expected to be running
+        /// </summary>
+        public string PoolId { get; }
+
+        /// <summary>
+        /// A unique identifier for the job within which the task is running
+        /// </summary>
+        public string JobId { get; }
+
+        /// <summary>
+        /// A unique identifier for the task itself
+        /// </summary>
+        public string TaskId { get; }
+
+        /// <summary>
         /// The audience for whom this entitlement is intended
         /// </summary>
         public string Audience { get; }
@@ -192,6 +217,56 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         }
 
         /// <summary>
+        /// Optionally specify the maximum number of CPU cores expected to be found on the machine
+        /// </summary>
+        /// <param name="cpuCoreCount">The number of CPU cores, or null if not required.</param>
+        /// <returns>A new entitlement.</returns>
+        public NodeEntitlements WithCpuCoreCount(int? cpuCoreCount)
+        {
+            return new NodeEntitlements(this, cpuCoreCount: Specify.As(cpuCoreCount));
+        }
+
+        /// <summary>
+        /// Specify the batch account ID with which the entitlement is associated
+        /// </summary>
+        /// <param name="batchAccountId">The batch account ID</param>
+        /// <returns>A new entitlement</returns>
+        public NodeEntitlements WithBatchAccountId(string batchAccountId)
+        {
+            return new NodeEntitlements(this, batchAccountId: Specify.As(batchAccountId));
+        }
+
+        /// <summary>
+        /// Specify the pool ID with which the entitlement is associated
+        /// </summary>
+        /// <param name="poolId">The pool ID</param>
+        /// <returns>A new entitlement</returns>
+        public NodeEntitlements WithPoolId(string poolId)
+        {
+            return new NodeEntitlements(this, poolId: Specify.As(poolId));
+        }
+
+        /// <summary>
+        /// Specify the job ID with which the entitlement is associated
+        /// </summary>
+        /// <param name="jobId">The job ID</param>
+        /// <returns>A new entitlement</returns>
+        public NodeEntitlements WithJobId(string jobId)
+        {
+            return new NodeEntitlements(this, jobId: Specify.As(jobId));
+        }
+
+        /// <summary>
+        /// Specify the task ID with which the entitlement is associated
+        /// </summary>
+        /// <param name="taskId">The task ID</param>
+        /// <returns>A new entitlement</returns>
+        public NodeEntitlements WithTaskId(string taskId)
+        {
+            return new NodeEntitlements(this, taskId: Specify.As(taskId));
+        }
+
+        /// <summary>
         /// Specify the audience to use in the token 
         /// </summary>
         /// <param name="audience">The audience for the generated token.</param>
@@ -234,6 +309,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <param name="applications">The set of applications entitled to run.</param>
         /// <param name="identifier">Identifier to use for this entitlement.</param>
         /// <param name="addresses">Addresses of the entitled machine.</param>
+        /// <param name="cpuCoreCount">Optionally specify a new value for <see cref="CpuCoreCount"/></param>
+        /// <param name="batchAccountId">Optionally specify a new value for <see cref="BatchAccountId"/></param>
+        /// <param name="poolId">Optionally specify a new value for <see cref="PoolId"/></param>
+        /// <param name="jobId">Optionally specify a new value for <see cref="JobId"/></param>
+        /// <param name="taskId">Optionally specify a new value for <see cref="TaskId"/></param>
         /// <param name="audience">Audience for whom the token is intended.</param>
         /// <param name="issuer">Issuer identifier for the token.</param>
         private NodeEntitlements(
@@ -245,6 +325,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             ImmutableHashSet<string> applications = null,
             Specifiable<string> identifier = default,
             ImmutableHashSet<IPAddress> addresses = null,
+            Specifiable<int?> cpuCoreCount = default,
+            Specifiable<string> batchAccountId = default,
+            Specifiable<string> poolId = default,
+            Specifiable<string> jobId = default,
+            Specifiable<string> taskId = default,
             Specifiable<string> audience = default,
             Specifiable<string> issuer = default)
         {
@@ -260,6 +345,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Applications = applications ?? original.Applications;
             Identifier = identifier.OrDefault(original.Identifier);
             IpAddresses = addresses ?? original.IpAddresses;
+            CpuCoreCount = cpuCoreCount.OrDefault(original.CpuCoreCount);
+            BatchAccountId = batchAccountId.OrDefault(original.BatchAccountId);
+            PoolId = poolId.OrDefault(original.PoolId);
+            JobId = jobId.OrDefault(original.JobId);
+            TaskId = taskId.OrDefault(original.TaskId);
             Audience = audience.OrDefault(original.Audience);
             Issuer = issuer.OrDefault(original.Issuer);
         }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 .With(provider.Audience()).Map((e, val) => e.WithAudience(val))
                 .With(provider.ApplicationIds()).Map((e, vals) => e.WithApplications(vals))
                 .With(provider.IpAddresses()).Map((e, vals) => e.WithIpAddresses(vals))
+				.With(provider.CpuCoreCount()).Map((e, val) => e.WithCpuCoreCount(val))
+				.With(provider.BatchAccountId()).Map((e, val) => e.WithBatchAccountId(val))
+				.With(provider.PoolId()).Map((e, val) => e.WithPoolId(val))
+				.With(provider.JobId()).Map((e, val) => e.WithJobId(val))
+				.With(provider.TaskId()).Map((e, val) => e.WithTaskId(val))
                 .With(provider.VirtualMachineId()).Map((e, val) => e.WithVirtualMachineId(val))
                 .With(provider.EntitlementId()).Map((e, val) => e.WithIdentifier(val));
         }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/StoredEntitlementHostVerifier.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/StoredEntitlementHostVerifier.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement
+{
+    /// <summary>
+    /// An in-memory store of entitlement IDs and the corresponding host ID values
+    /// with which they have been used. For ensuring that every entitlement is only
+    /// used by a single host.
+    /// </summary>
+    public class StoredEntitlementHostVerifier : IHostVerifier
+    {
+        private readonly ConcurrentDictionary<string, string> _lookup = new ConcurrentDictionary<string, string>();
+
+        /// <summary>
+        /// Performs a check to verify that the entitlement was not previously
+        /// associated with a different host.
+        /// </summary>
+        /// <param name="entitlement">The entitlement ID</param>
+        /// <param name="hostId">The host ID</param>
+        /// <returns>
+        /// True if the entitlement is new or previously associated with the same host,
+        /// false if it was previously associated with a different host.
+        /// </returns>
+        public bool Verify(NodeEntitlements entitlement, string hostId)
+        {
+            var storedHostId = _lookup.GetOrAdd(entitlement.Identifier, hostId);
+            return storedHostId == hostId;
+        }
+    }
+}

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using Microsoft.Extensions.Logging;
@@ -113,16 +114,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             AddClaim(claims, Claims.JobId, "Job id", entitlements.JobId);
             AddClaim(claims, Claims.TaskId, "Task id", entitlements.TaskId);
             AddClaim(claims, Claims.EntitlementId, "Entitlement id", entitlements.Identifier);
-
-            foreach (var ip in entitlements.IpAddresses)
-            {
-                AddClaim(claims, Claims.IpAddress, "IP address", ip.ToString());
-            }
-
-            foreach (var app in entitlements.Applications)
-            {
-                AddClaim(claims, Claims.Application, "Application id", app);
-            }
+            AddClaims(claims, Claims.IpAddress, "IP address", entitlements.IpAddresses.Select(ip => ip.ToString()));
+            AddClaims(claims, Claims.Application, "Application id", entitlements.Applications);
 
             return claims;
         }
@@ -133,6 +126,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             {
                 _logger.LogDebug($"{claimName}: {{{claimId}}}", claimValue);
                 claims.Add(new Claim(claimId, claimValue));
+            }
+        }
+
+        private void AddClaims(IList<Claim> claims, string claimId, string claimName, IEnumerable<string> claimValues)
+        {
+            foreach (var claimValue in claimValues)
+            {
+                AddClaim(claims, claimId, claimName, claimValue);
             }
         }
     }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/TokenGenerator.cs
@@ -106,32 +106,34 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             var claims = new List<Claim>();
 
-            if (!string.IsNullOrEmpty(entitlements.VirtualMachineId))
-            {
-                _logger.LogDebug("Virtual machine Id: {VirtualMachineId}", entitlements.VirtualMachineId);
-                claims.Add(new Claim(Claims.VirtualMachineId, entitlements.VirtualMachineId));
-            }
-
-            if (!string.IsNullOrEmpty(entitlements.Identifier))
-            {
-                _logger.LogDebug("Entitlement Id: {EntitlementId}", entitlements.Identifier);
-                claims.Add(new Claim(Claims.EntitlementId, entitlements.Identifier));
-            }
+            AddClaim(claims, Claims.VirtualMachineId, "Virtual machine id", entitlements.VirtualMachineId);
+            AddClaim(claims, Claims.CpuCoreCount, "CPU core count", entitlements.CpuCoreCount?.ToString(CultureInfo.InvariantCulture));
+            AddClaim(claims, Claims.BatchAccountId, "Batch account id", entitlements.BatchAccountId);
+            AddClaim(claims, Claims.PoolId, "Pool id", entitlements.PoolId);
+            AddClaim(claims, Claims.JobId, "Job id", entitlements.JobId);
+            AddClaim(claims, Claims.TaskId, "Task id", entitlements.TaskId);
+            AddClaim(claims, Claims.EntitlementId, "Entitlement id", entitlements.Identifier);
 
             foreach (var ip in entitlements.IpAddresses)
             {
-                _logger.LogDebug("IP Address: {IP}", ip);
-                claims.Add(new Claim(Claims.IpAddress, ip.ToString()));
+                AddClaim(claims, Claims.IpAddress, "IP address", ip.ToString());
             }
 
             foreach (var app in entitlements.Applications)
             {
-                _logger.LogDebug("Application Id: {ApplicationId}", app);
-                var claim = new Claim(Claims.Application, app);
-                claims.Add(claim);
+                AddClaim(claims, Claims.Application, "Application id", app);
             }
 
             return claims;
+        }
+
+        private void AddClaim(IList<Claim> claims, string claimId, string claimName, string claimValue)
+        {
+            if (!string.IsNullOrEmpty(claimValue))
+            {
+                _logger.LogDebug($"{claimName}: {{{claimId}}}", claimValue);
+                claims.Add(new Claim(claimId, claimValue));
+            }
         }
     }
 }

--- a/src/sestest/CommandLineEntitlementPropertyProvider.cs
+++ b/src/sestest/CommandLineEntitlementPropertyProvider.cs
@@ -80,19 +80,19 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             return Errorable.Success(_commandLine.Issuer);
         }
 
-        private Errorable<int> CpuCoreCount()
+        public Errorable<int> CpuCoreCount()
         {
             // if the user does not specify a cpu core count, we default to the number of logical cores on the current machine
             return Errorable.Success(_commandLine.CpuCoreCount ?? Environment.ProcessorCount);
         }
 
-        private Errorable<string> BatchAccountId() => Errorable.Success(_commandLine.BatchAccountId);
+        public Errorable<string> BatchAccountId() => Errorable.Success(_commandLine.BatchAccountId);
 
-        private Errorable<string> PoolId() => Errorable.Success(_commandLine.PoolId);
+        public Errorable<string> PoolId() => Errorable.Success(_commandLine.PoolId);
 
-        private Errorable<string> JobId() => Errorable.Success(_commandLine.JobId);
+        public Errorable<string> JobId() => Errorable.Success(_commandLine.JobId);
 
-        private Errorable<string> TaskId() => Errorable.Success(_commandLine.TaskId);
+        public Errorable<string> TaskId() => Errorable.Success(_commandLine.TaskId);
 
         public Errorable<IEnumerable<IPAddress>> IpAddresses()
         {

--- a/src/sestest/CommandLineEntitlementPropertyProvider.cs
+++ b/src/sestest/CommandLineEntitlementPropertyProvider.cs
@@ -80,6 +80,20 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             return Errorable.Success(_commandLine.Issuer);
         }
 
+        private Errorable<int> CpuCoreCount()
+        {
+            // if the user does not specify a cpu core count, we default to the number of logical cores on the current machine
+            return Errorable.Success(_commandLine.CpuCoreCount ?? Environment.ProcessorCount);
+        }
+
+        private Errorable<string> BatchAccountId() => Errorable.Success(_commandLine.BatchAccountId);
+
+        private Errorable<string> PoolId() => Errorable.Success(_commandLine.PoolId);
+
+        private Errorable<string> JobId() => Errorable.Success(_commandLine.JobId);
+
+        private Errorable<string> TaskId() => Errorable.Success(_commandLine.TaskId);
+
         public Errorable<IEnumerable<IPAddress>> IpAddresses()
         {
             var result = new List<Errorable<IPAddress>>();

--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -37,5 +37,20 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
         [Option("issuer", HelpText = "[Internal] Issuer by whom the tokens are created (optional, defaults to '" + Claims.DefaultIssuer + "').")]
         public string Issuer { get; set; }
+
+        [Option("maxcores", HelpText = "The maximum number of CPU cores allowed on the machine entitled to execute the application(s) (defaults to the number of logical cores on the current machine).")]
+        public int? CpuCoreCount { get; set; }
+
+        [Option("batch-account-id", HelpText = "The id of the batch account under which the application is assumed to be running (optional).")]
+        public string BatchAccountId { get; set; }
+
+        [Option("pool-id", HelpText = "The id of the pool in which the application is assumed to be running (optional).")]
+        public string PoolId { get; set; }
+
+        [Option("job-id", HelpText = "The id of the job in which the application is assumed to be running (optional).")]
+        public string JobId { get; set; }
+
+        [Option("task-id", HelpText = "The id of the task which the application is assumed to be running (optional).")]
+        public string TaskId { get; set; }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/EntitlementVerifierTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/EntitlementVerifierTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             SecurityKey encryptingKey)
         {
             var parser = new JwtEntitlementParser(expectedAudience, expectedIssuer, signingKey, encryptingKey);
-            return new EntitlementVerifier(parser);
+            return new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
         }
 
         public class Verify : EntitlementVerifierTests
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             [Fact]
             public void WhenTokenIsNull_ThrowsException()
             {
-                var verifier = new EntitlementVerifier(new FakeEntitlementParser());
+                var verifier = new EntitlementVerifier(new FakeEntitlementParser(), new StoredEntitlementHostVerifier());
                 Assert.Throws<ArgumentNullException>(
                     () => verifier.Verify(_validEntitlementRequest, null));
             }
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithApplications();
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.ApplicationId));
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithApplications(_validEntitlementRequest.ApplicationId);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeTrue();
             }
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithApplications(_otherApp1);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.ApplicationId));
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithApplications(_otherApp1, _otherApp2);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.ApplicationId));
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 var entitlement = _completeEntitlement.WithApplications(
                     _validEntitlementRequest.ApplicationId, _otherApp1, _otherApp2);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeTrue();
             }
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithIpAddresses();
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.IpAddress.ToString()));
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithIpAddresses(_validEntitlementRequest.IpAddress);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeTrue();
             }
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithIpAddresses(_otherAddress1);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.IpAddress.ToString()));
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             {
                 var entitlement = _completeEntitlement.WithIpAddresses(_otherAddress1, _otherAddress2);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains(_validEntitlementRequest.IpAddress.ToString()));
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 var entitlement = _completeEntitlement.WithIpAddresses(
                     _validEntitlementRequest.IpAddress, _otherAddress1, _otherAddress2);
                 var parser = new FakeEntitlementParser(_testToken, entitlement);
-                var verifier = new EntitlementVerifier(parser);
+                var verifier = new EntitlementVerifier(parser, new StoredEntitlementHostVerifier());
                 var result = verifier.Verify(_validEntitlementRequest, _testToken);
                 result.HasValue.Should().BeTrue();
             }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/FakeEntitlementPropertyProvider.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/FakeEntitlementPropertyProvider.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
                 Issuer = Errorable.Success("https://issuer.region.batch.azure.test"),
                 NotAfter = Errorable.Success(now + TimeSpan.FromDays(7)),
                 NotBefore = Errorable.Success(now),
-                VirtualMachineId = Errorable.Success("Sample")
+                VirtualMachineId = Errorable.Success("Sample"),
+                CpuCoreCount = Errorable.Success(4),
+                BatchAccountId = Errorable.Success((string)null),
+                PoolId = Errorable.Success((string)null),
+                JobId = Errorable.Success((string)null),
+                TaskId = Errorable.Success((string)null)
             };
         }
 
@@ -43,6 +48,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 
         public Errorable<string> VirtualMachineId { get; set; }
 
+        public Errorable<int> CpuCoreCount { get; set; }
+
+        public Errorable<string> BatchAccountId { get; set; }
+
+        public Errorable<string> PoolId { get; set; }
+
+        public Errorable<string> JobId { get; set; }
+
+        public Errorable<string> TaskId { get; set; }
+
         Errorable<IEnumerable<string>> IEntitlementPropertyProvider.ApplicationIds() => ApplicationIds;
 
         Errorable<string> IEntitlementPropertyProvider.Audience() => Audience;
@@ -50,6 +65,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         Errorable<string> IEntitlementPropertyProvider.EntitlementId() => EntitlementId;
 
         Errorable<IEnumerable<IPAddress>> IEntitlementPropertyProvider.IpAddresses() => IpAddresses;
+
+        Errorable<int> IEntitlementPropertyProvider.CpuCoreCount() => CpuCoreCount;
+
+        Errorable<string> IEntitlementPropertyProvider.BatchAccountId() => BatchAccountId;
+
+        Errorable<string> IEntitlementPropertyProvider.PoolId() => PoolId;
+
+        Errorable<string> IEntitlementPropertyProvider.JobId() => JobId;
+
+        Errorable<string> IEntitlementPropertyProvider.TaskId() => TaskId;
 
         Errorable<DateTimeOffset> IEntitlementPropertyProvider.IssuedAt() => IssuedAt;
 


### PR DESCRIPTION
Changes are to the C# (test and server) components, not the native SDK or client

Questions/assumptions:
 - Do we need to implement batchaccount, poolid, jobid, and taskid claims for the generated test tokens and read them in the server, given that they're not actually checked/used?
 - Assumption: ApiVersion201709 is v2
 - Assumption: the token is always the latest version (including the new claims), but the server needs to support all API versions
 - In token generation, should IP addresses be space-separated while applications are comma-separated?
