### PR TITLE
Specifiable

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
@@ -1,0 +1,45 @@
+namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
+{
+    /// <summary>
+    /// Represents a value which may or may not be specified.
+    /// </summary>
+    /// <remarks>
+    /// This is independent of whether the value is null or not;
+    /// a value may be specified as null.
+    /// </remarks>
+    /// <typeparam name="T">The type of the value to be specified.</typeparam>
+    public struct Specifiable<T>
+    {
+        /// <summary>
+        /// Whether the value is specified.
+        /// </summary>
+        public bool IsSpecified;
+
+        private T _value;
+
+        /// <summary>
+        /// Initializes a new instance of a specifiable value interpreted as
+        /// being specified.
+        /// </summary>
+        /// <remarks>
+        /// To create an unspecified instance, use the default (parameterless)
+        /// constructor.
+        /// </remarks>
+        /// <param name="value">The specified value (can be null).</param>
+        public Specifiable(T value)
+        {
+            IsSpecified = true;
+            _value = value;
+        }
+
+        /// <summary>
+        /// Returns a default value if the current instance is not specified.
+        /// </summary>
+        /// <param name="other">The value to return if this instance is not specified</param>
+        /// <returns>
+        /// The specified value if this instance is specified, otherwise returns the
+        /// <paramref name="other"/> value.
+        /// </returns>
+        public T OrDefault(T other) => IsSpecified ? _value : other;
+    }
+}

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <summary>
         /// Whether the value is specified.
         /// </summary>
-        public bool IsSpecified;
+        public bool IsSpecified { get; }
 
         private T _value;
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specify.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specify.cs
@@ -1,0 +1,16 @@
+namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
+{
+    /// <summary>
+    /// Static factory methods for <see cref="Specifiable{T}"/>
+    /// </summary>
+    public static class Specify
+    {
+        /// <summary>
+        /// Creates a new <see cref="Specifiable{T}"/> with the specified value.
+        /// </summary>
+        /// <typeparam name="T">The type of the value to be specified.</typeparam>
+        /// <param name="value">The value to be specified.</param>
+        /// <returns>New instance.</returns>
+        public static Specifiable<T> As<T>(T value) => new Specifiable<T>(value);
+    }
+}

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
+{
+    public class SpecifiableTests
+    {
+        private readonly Specifiable<string> _defaultOfString = default;
+
+        public class Construction : SpecifiableTests
+        {
+            [Fact]
+            public void CreatedAsParameterlessNew_IsNotSpecified()
+            {
+                var result = new Specifiable<string>();
+                result.IsSpecified.Should().BeFalse();
+            }
+
+            [Fact]
+            public void CreatedAsDefault_IsNotSpecified()
+            {
+                var result = _defaultOfString;
+                result.IsSpecified.Should().BeFalse();
+            }
+
+            [Fact]
+            public void CreatedWithValue_IsSpecified()
+            {
+                const string value = "test";
+                var result = new Specifiable<string>(value);
+                result.IsSpecified.Should().BeTrue();
+            }
+
+            [Fact]
+            public void CreatedWithNull_IsSpecified()
+            {
+                const string value = null;
+                var result = new Specifiable<string>(value);
+                result.IsSpecified.Should().BeTrue();
+            }
+
+            [Fact]
+            public void CreatedBySpecifyAsValue_IsSpecified()
+            {
+                const string value = "test";
+                var result = Specify.As(value);
+                result.IsSpecified.Should().BeTrue();
+            }
+
+            [Fact]
+            public void CreatedBySpecifyAsNull_IsSpecified()
+            {
+                const string value = null;
+                var result = Specify.As(value);
+                result.IsSpecified.Should().BeTrue();
+            }
+        }
+
+        public class OrDefault : SpecifiableTests
+        {
+            [Fact]
+            public void WhenSpecifiedAsValue_ReturnsInstanceValue()
+            {
+                const string thisValue = "this";
+                const string otherValue = "other";
+                var result = Specify.As(thisValue).OrDefault(otherValue);
+                result.Should().Be(thisValue);
+            }
+
+            [Fact]
+            public void WhenSpecifiedAsNull_ReturnsNull()
+            {
+                const string thisValue = null;
+                const string otherValue = "other";
+                var result = Specify.As(thisValue).OrDefault(otherValue);
+                result.Should().BeNull();
+            }
+
+            [Fact]
+            public void WhenNotSpecified_ReturnsOtherValue()
+            {
+                const string otherValue = "other";
+                var result = _defaultOfString.OrDefault(otherValue);
+                result.Should().Be(otherValue);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
     {
         private readonly Specifiable<string> _defaultOfString = default;
 
+        // Values to specify
+        private readonly string _thisStringValue = "this";
+        private readonly string _nullStringValue;
+
         public class Construction : SpecifiableTests
         {
             [Fact]
@@ -26,62 +30,58 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             [Fact]
             public void CreatedWithValue_IsSpecified()
             {
-                const string value = "test";
-                var result = new Specifiable<string>(value);
+                var result = new Specifiable<string>(_thisStringValue);
                 result.IsSpecified.Should().BeTrue();
             }
 
             [Fact]
             public void CreatedWithNull_IsSpecified()
             {
-                const string value = null;
-                var result = new Specifiable<string>(value);
+                var result = new Specifiable<string>(_nullStringValue);
+                result.IsSpecified.Should().BeTrue();
+            }
+        }
+
+        public class SpecifyAs : SpecifiableTests
+        {
+            [Fact]
+            public void WithValue_IsSpecified()
+            {
+                var result = Specify.As(_thisStringValue);
                 result.IsSpecified.Should().BeTrue();
             }
 
             [Fact]
-            public void CreatedBySpecifyAsValue_IsSpecified()
+            public void WithNull_IsSpecified()
             {
-                const string value = "test";
-                var result = Specify.As(value);
-                result.IsSpecified.Should().BeTrue();
-            }
-
-            [Fact]
-            public void CreatedBySpecifyAsNull_IsSpecified()
-            {
-                const string value = null;
-                var result = Specify.As(value);
+                var result = Specify.As(_nullStringValue);
                 result.IsSpecified.Should().BeTrue();
             }
         }
 
         public class OrDefault : SpecifiableTests
         {
+            private readonly string _otherStringValue = "other";
+
             [Fact]
             public void WhenSpecifiedAsValue_ReturnsInstanceValue()
             {
-                const string thisValue = "this";
-                const string otherValue = "other";
-                var result = Specify.As(thisValue).OrDefault(otherValue);
-                result.Should().Be(thisValue);
+                var result = Specify.As(_thisStringValue).OrDefault(_otherStringValue);
+                result.Should().Be(_thisStringValue);
             }
 
             [Fact]
             public void WhenSpecifiedAsNull_ReturnsNull()
             {
-                const string thisValue = null;
-                const string otherValue = "other";
-                var result = Specify.As(thisValue).OrDefault(otherValue);
+                var result = Specify.As(_nullStringValue).OrDefault(_otherStringValue);
                 result.Should().BeNull();
             }
 
             [Fact]
             public void WhenNotSpecified_ReturnsOtherValue()
             {
-                const string otherValue = "other";
-                var result = _defaultOfString.OrDefault(otherValue);
-                result.Should().Be(otherValue);
+                var result = _defaultOfString.OrDefault(_otherStringValue);
+                result.Should().Be(_otherStringValue);
             }
         }
     }


### PR DESCRIPTION
Added Specifiable type for distinguishing between unspecified values and values specified as null.

Specifically for the case where we're supplying multiple optional parameters (for which null might be a valid value) to a constructor.