### PR TITLE
A spike to remove ServerOptionsBuilderOptions from the public API

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Errorable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Errorable.cs
@@ -172,7 +172,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 
             public override bool HasValue => false;
 
-            public override T Value => throw new InvalidOperationException($"No value of type {typeof(T).Name} available ({string.Join("; ", Errors)}).");
+            public override T Value => throw new InvalidOperationException(
+                $"No value of type {typeof(T).Name} available ({string.Join("; ", Errors)}).");
 
             public override ImmutableHashSet<string> Errors { get; }
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Errorable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Errorable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 
             public override bool HasValue => false;
 
-            public override T Value => throw new InvalidOperationException($"No value of type {typeof(T).Name} available.");
+            public override T Value => throw new InvalidOperationException($"No value of type {typeof(T).Name} available ({string.Join("; ", Errors)}).");
 
             public override ImmutableHashSet<string> Errors { get; }
 

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Exit code to return from this process.</returns>
         public static async Task<int> Serve(ServerCommandLine commandLine)
         {
-            var options = ServerOptionBuilder.Build(commandLine);
+            var options = new ServerOptionBuilder(commandLine).Build();
             return await options.Match(
                 RunServer,
                 errors =>

--- a/src/sestest/ServerOptionBuilder.cs
+++ b/src/sestest/ServerOptionBuilder.cs
@@ -18,36 +18,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         // Reference to a store in which we can search for certificates
         private readonly CertificateStore _certificateStore = new CertificateStore();
 
-        // Options used to configure validation
-        private readonly ServerOptionBuilderOptions _options;
-
-        /// <summary>
-        /// Build an instance of <see cref="ServerOptions"/> from the information supplied on the 
-        /// command line by the user
-        /// </summary>
-        /// <param name="commandLine">Command line parameters supplied by the user.</param>
-        /// <param name="options">Options for configuring validation.</param>
-        /// <returns>Either a usable (and completely valid) <see cref="ServerOptions"/> or a set 
-        /// of errors.</returns>
-        public static Errorable<ServerOptions> Build(
-            ServerCommandLine commandLine,
-            ServerOptionBuilderOptions options = ServerOptionBuilderOptions.None)
-        {
-            var builder = new ServerOptionBuilder(commandLine, options);
-            return builder.Build();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerOptionBuilder"/> class
         /// </summary>
         /// <param name="commandLine">Options provided on the command line.</param>
-        /// <param name="options">Options for configuring validation.</param>
-        private ServerOptionBuilder(
-            ServerCommandLine commandLine,
-            ServerOptionBuilderOptions options)
+        public ServerOptionBuilder(
+            ServerCommandLine commandLine)
         {
             _commandLine = commandLine;
-            _options = options;
         }
 
         /// <summary>
@@ -56,7 +34,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// </summary>
         /// <returns>Either a usable (and completely valid) <see cref="ServerOptions"/> or a set 
         /// of errors.</returns>
-        private Errorable<ServerOptions> Build()
+        public Errorable<ServerOptions> Build()
         {
             var result = Errorable.Success(new ServerOptions())
                 .Configure(ServerUrl(), (opt, url) => opt.WithServerUrl(url))
@@ -75,15 +53,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// </summary>
         /// <returns>An <see cref="Errorable{Uri}"/> containing either the URL to use or any 
         /// relevant errors.</returns>
-        private Errorable<Uri> ServerUrl()
+        protected virtual Errorable<Uri> ServerUrl()
         {
             if (string.IsNullOrWhiteSpace(_commandLine.ServerUrl))
             {
-                if (_options.HasFlag(ServerOptionBuilderOptions.ServerUrlOptional))
-                {
-                    return Errorable.Success(new Uri("http://test"));
-                }
-
                 return Errorable.Failure<Uri>("No server endpoint URL specified.");
             }
 
@@ -107,15 +80,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// Find the certificate to use for HTTPS connections
         /// </summary>
         /// <returns>Certificate, if found; error details otherwise.</returns>
-        private Errorable<X509Certificate2> ConnectionCertificate()
+        protected virtual Errorable<X509Certificate2> ConnectionCertificate()
         {
             if (string.IsNullOrEmpty(_commandLine.ConnectionCertificateThumbprint))
             {
-                if (_options.HasFlag(ServerOptionBuilderOptions.ConnectionThumbprintOptional))
-                {
-                    return Errorable.Success<X509Certificate2>(null);
-                }
-
                 return Errorable.Failure<X509Certificate2>("A connection thumbprint is required.");
             }
 
@@ -205,13 +173,5 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             var certificateThumbprint = new CertificateThumbprint(thumbprint);
             return _certificateStore.FindByThumbprint(purpose, certificateThumbprint);
         }
-    }
-
-    [Flags]
-    public enum ServerOptionBuilderOptions
-    {
-        None,
-        ServerUrlOptional,
-        ConnectionThumbprintOptional
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderFake.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderFake.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
+{
+    public class ServerOptionBuilderFake : ServerOptionBuilder
+    {
+        private readonly ServerOptionBuilderOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerOptionBuilder"/> class
+        /// </summary>
+        /// <param name="commandLine">Options provided on the command line.</param>
+        /// <param name="options">Options for configuring validation.</param>
+        public ServerOptionBuilderFake(
+            ServerCommandLine commandLine,
+            ServerOptionBuilderOptions options)
+            : base(commandLine)
+        {
+            _options = options;
+        }
+
+        protected override Errorable<Uri> ServerUrl()
+        {
+            if (_options.HasFlag(ServerOptionBuilderOptions.ServerUrlOptional))
+            {
+                return Errorable.Success(new Uri("http://test"));
+            }
+
+            return base.ServerUrl();
+        }
+
+        protected override Errorable<X509Certificate2> ConnectionCertificate()
+        {
+            if (_options.HasFlag(ServerOptionBuilderOptions.ConnectionThumbprintOptional))
+            {
+                return Errorable.Success<X509Certificate2>(null);
+            }
+
+            return base.ConnectionCertificate();
+        }
+    }
+
+    [Flags]
+    public enum ServerOptionBuilderOptions
+    {
+        None,
+        ServerUrlOptional,
+        ConnectionThumbprintOptional
+    }
+}

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderFake.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderFake.cs
@@ -4,6 +4,10 @@ using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
 {
+    /// <summary>
+    /// A fake version of <see cref="ServerOptionBuilder"/> that allows some validation to be disabled 
+    /// to allow testing of other code paths
+    /// </summary>
     public class ServerOptionBuilderFake : ServerOptionBuilder
     {
         private readonly ServerOptionBuilderOptions _options;
@@ -21,6 +25,15 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             _options = options;
         }
 
+        /// <summary>
+        /// Find the server URL for our hosting
+        /// </summary>
+        /// <remarks>
+        /// Can be disabled by passing <see cref="ServerOptionBuilderOptions.ServerUrlOptional"/> 
+        /// to the constructor.
+        /// </remarks>
+        /// <returns>An <see cref="Errorable{Uri}"/> containing either the URL to use or any 
+        /// relevant errors.</returns>
         protected override Errorable<Uri> ServerUrl()
         {
             if (_options.HasFlag(ServerOptionBuilderOptions.ServerUrlOptional))
@@ -31,6 +44,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             return base.ServerUrl();
         }
 
+        /// <summary>
+        /// Find the certificate to use for HTTPS connections
+        /// </summary>
+        /// <remarks>
+        /// Can be disabled by passing <see cref="ServerOptionBuilderOptions.ConnectionThumbprintOptional"/> 
+        /// to the constructor.
+        /// </remarks>
+        /// <returns>Certificate, if found; error details otherwise.</returns>
         protected override Errorable<X509Certificate2> ConnectionCertificate()
         {
             if (_options.HasFlag(ServerOptionBuilderOptions.ConnectionThumbprintOptional))
@@ -42,6 +63,10 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         }
     }
 
+    /// <summary>
+    /// Options used to disable selected validation with <see cref="ServerOptionBuilder"/> 
+    /// for testing purposes.
+    /// </summary>
     [Flags]
     public enum ServerOptionBuilderOptions
     {

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             [Fact]
             public void Build_WithEmptyServerUrl_DoesNotReturnValue()
             {
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.HasValue.Should().BeFalse();
             }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyServerUrl_HasErrorForServerUrl()
             {
                 _commandLine.ServerUrl = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.Errors.Should().Contain(e => e.Contains("server endpoint URL"));
             }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithHttpServerUrl_HasErrorForServerUrl()
             {
                 _commandLine.ServerUrl = "http://www.example.com";
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.Errors.Should().Contain(e => e.Contains("Server endpoint URL"));
             }
 
@@ -49,7 +49,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void WithValidServerUrl_ConfigureServerUrl()
             {
                 _commandLine.ServerUrl = "https://example.com/";
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = new ServerOptionBuilderFake(
+                    _commandLine, ServerOptionBuilderOptions.ConnectionThumbprintOptional)
+                    .Build();
                 options.Value.ServerUrl.ToString().Should().Be(_commandLine.ServerUrl);
             }
         }
@@ -60,7 +62,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithNoConnectionThumbprint_DoesNotReturnValue()
             {
                 _commandLine.ConnectionCertificateThumbprint = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.HasValue.Should().BeFalse();
             }
 
@@ -68,7 +70,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithNoConnectionThumbprint_HasErrorForConnection()
             {
                 _commandLine.ConnectionCertificateThumbprint = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.Errors.Should().Contain(e => e.Contains("connection"));
             }
 
@@ -76,7 +78,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithUnknownConnectionThumbprint_HasErrorForConnection()
             {
                 _commandLine.ConnectionCertificateThumbprint = _thumbprint;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = new ServerOptionBuilder(_commandLine).Build();
                 options.Errors.Should().Contain(e => e.Contains("connection"));
             }
         }
@@ -87,7 +89,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyAudience_HasDefaultValueForAudience()
             {
                 _commandLine.Audience = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = new ServerOptionBuilderFake(_commandLine, _permissiveOptions).Build();
                 options.Value.Audience.Should().NotBeNullOrEmpty();
             }
         }
@@ -98,7 +100,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyIssuer_HasDefaultValueForIssuer()
             {
                 _commandLine.Issuer = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = new ServerOptionBuilderFake(_commandLine, _permissiveOptions).Build();
                 options.Value.Issuer.Should().NotBeNullOrEmpty();
             }
         }
@@ -109,7 +111,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithoutExitAfterRequest_ShouldHaveDefault()
             {
                 _commandLine.ExitAfterRequest = false;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = new ServerOptionBuilderFake(_commandLine, _permissiveOptions).Build();
                 options.Value.ExitAfterRequest.Should().BeFalse();
             }
 
@@ -117,7 +119,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithExitAfterRequest_ConfiguresValue()
             {
                 _commandLine.ExitAfterRequest = true;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = new ServerOptionBuilderFake(_commandLine, _permissiveOptions).Build();
                 options.Value.ExitAfterRequest.Should().BeTrue();
             }
         }


### PR DESCRIPTION
For consideration - moving `ServerOptionsBuilderOptions` out of the public API and into the test assembly.

* Cleans up the public class so there's much less that's imposed by testing constraints

* Allows removal of the static method (which was only there to conceal `ServerOptionsBuilderOptions` in the first place)