### PR TITLE
Fix bug using environment variable for Server URL

### DIFF
--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             try
             {
-                return Errorable.Success(new Uri(commandLine.Server));
+                return Errorable.Success(new Uri(server));
             }
             catch (UriFormatException ex)
             {


### PR DESCRIPTION
Fixes a bug when specifying the URL in the AZ_BATCH_ACCOUNT_URL where the value specified was ignored.