### PR TITLE
Make use of Specifiable

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/ErrorableExtensions.cs
@@ -324,33 +324,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         }
 
         /// <summary>
-        /// Configure an existing subject using an optionally supplied value and transformation
-        /// </summary>
-        /// <remarks>Preserves any/all errors present on <paramref name="subject"/> and <paramref name="value"/>.</remarks>
-        /// <typeparam name="S">Type of the subject to configure.</typeparam>
-        /// <typeparam name="V">Type of the value to use for configuration.</typeparam>
-        /// <param name="subject">Subject instance to configure, wrapped as an <see cref="Errorable{T}"/></param>
-        /// <param name="value">Value to use for configuration, wrapped as an <see cref="Errorable{T}"/>; null if not available.</param>
-        /// <param name="applyConfiguration">Action to use for configuration.</param>
-        /// <returns>Result of configuration.</returns>
-        public static Errorable<S> ConfigureOptional<S, V>(this Errorable<S> subject, Errorable<V> value, Func<S, V, S> applyConfiguration)
-            where V : class
-        {
-            if (subject == null)
-            {
-                throw new ArgumentNullException(nameof(subject));
-            }
-
-            if (value == null)
-            {
-                return subject;
-            }
-
-            return subject.With(value).Map((s, v) => v != null ? applyConfiguration(s, v) : s);
-        }
-
-
-        /// <summary>
         /// Configure an existing subject using a sequences of supplied values and transformation for each one
         /// </summary>
         /// <remarks>Preserves any/all errors present on <paramref name="subject"/> and <paramref name="values"/>.</remarks>
@@ -373,31 +346,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             }
 
             return values.Aggregate(subject, (current, v) => current.With(v).Map(applyConfiguration));
-        }
-
-
-        /// <summary>
-        /// Configure an existing subject using a bool value and transformation to apply if true
-        /// </summary>
-        /// <remarks>Preserves any/all errors present on <paramref name="subject"/> and <paramref name="value"/>.</remarks>
-        /// <typeparam name="S">Type of the subject to configure.</typeparam>
-        /// <param name="subject">Subject instance to configure, wrapped as an <see cref="Errorable{T}"/>.</param>
-        /// <param name="value">Switch value to use (if true, our configuration will be activated).</param>
-        /// <param name="applyConfiguration">Action to use for configuration.</param>
-        /// <returns>Result of configuration.</returns>
-        public static Errorable<S> ConfigureSwitch<S>(this Errorable<S> subject, Errorable<bool> value, Func<S, S> applyConfiguration)
-        {
-            if (subject == null)
-            {
-                throw new ArgumentNullException(nameof(subject));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return subject.With(value).Map((s, v) => v ? applyConfiguration(s) : s);
         }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/NodeEntitlements.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Immutable;
 using System.Net;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {
@@ -78,12 +79,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>A new entitlement.</returns>
         public NodeEntitlements WithVirtualMachineId(string virtualMachineId)
         {
-            if (string.IsNullOrEmpty(virtualMachineId))
+            if (virtualMachineId == null)
             {
                 throw new ArgumentNullException(nameof(virtualMachineId));
             }
 
-            return new NodeEntitlements(this, virtualMachineId: virtualMachineId);
+            return new NodeEntitlements(this, virtualMachineId: Specify.As(virtualMachineId));
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>A new entitlement.</returns>
         public NodeEntitlements FromInstant(DateTimeOffset notBefore)
         {
-            return new NodeEntitlements(this, notBefore: notBefore);
+            return new NodeEntitlements(this, notBefore: Specify.As(notBefore));
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns></returns>
         public NodeEntitlements UntilInstant(DateTimeOffset notAfter)
         {
-            return new NodeEntitlements(this, notAfter: notAfter);
+            return new NodeEntitlements(this, notAfter: Specify.As(notAfter));
         }
 
         /// <summary>
@@ -148,7 +149,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentException("Expect to have an identifier", nameof(identifier));
             }
 
-            return new NodeEntitlements(this, identifier: identifier);
+            return new NodeEntitlements(this, identifier: Specify.As(identifier));
         }
 
         /// <summary>
@@ -163,7 +164,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentException("Expect to have an audience", nameof(audience));
             }
 
-            return new NodeEntitlements(this, audience: audience);
+            return new NodeEntitlements(this, audience: Specify.As(audience));
         }
 
         /// <summary>
@@ -178,7 +179,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentException("Expect to have an issuer", nameof(issuer));
             }
 
-            return new NodeEntitlements(this, issuer: issuer);
+            return new NodeEntitlements(this, issuer: Specify.As(issuer));
         }
 
         /// <summary>
@@ -197,25 +198,29 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <param name="issuer">Issuer identifier for the token.</param>
         private NodeEntitlements(
             NodeEntitlements original,
-            DateTimeOffset? notBefore = null,
-            DateTimeOffset? notAfter = null,
-            string virtualMachineId = null,
+            Specifiable<DateTimeOffset> notBefore = default,
+            Specifiable<DateTimeOffset> notAfter = default,
+            Specifiable<string> virtualMachineId = default,
             ImmutableHashSet<string> applications = null,
-            string identifier = null,
+            Specifiable<string> identifier = default,
             ImmutableHashSet<IPAddress> addresses = null,
-            string audience = null,
-            string issuer = null)
+            Specifiable<string> audience = default,
+            Specifiable<string> issuer = default)
         {
-            Created = original.Created;
+            if (original == null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
 
-            NotBefore = notBefore ?? original.NotBefore;
-            NotAfter = notAfter ?? original.NotAfter;
-            VirtualMachineId = virtualMachineId ?? original.VirtualMachineId;
+            Created = original.Created;
+            NotBefore = notBefore.OrDefault(original.NotBefore);
+            NotAfter = notAfter.OrDefault(original.NotAfter);
+            VirtualMachineId = virtualMachineId.OrDefault(original.VirtualMachineId);
             Applications = applications ?? original.Applications;
-            Identifier = identifier ?? original.Identifier;
+            Identifier = identifier.OrDefault(original.Identifier);
             IpAddresses = addresses ?? original.IpAddresses;
-            Audience = audience ?? original.Audience;
-            Issuer = issuer ?? original.Issuer;
+            Audience = audience.OrDefault(original.Audience);
+            Issuer = issuer.OrDefault(original.Issuer);
         }
     }
 }

--- a/src/sestest/NodeEntitlementsBuilder.cs
+++ b/src/sestest/NodeEntitlementsBuilder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         private Errorable<NodeEntitlements> Build()
         {
             var result = Errorable.Success(new NodeEntitlements())
-                .ConfigureOptional(VirtualMachineId(), (e, url) => e.WithVirtualMachineId(url))
+                .Configure(VirtualMachineId(), (e, url) => e.WithVirtualMachineId(url))
                 .Configure(NotBefore(), (e, notBefore) => e.FromInstant(notBefore))
                 .Configure(NotAfter(), (e, notAfter) => e.UntilInstant(notAfter))
                 .Configure(Audience(), (e, audience) => e.WithAudience(audience))
@@ -66,13 +66,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
         private Errorable<string> VirtualMachineId()
         {
-            if (string.IsNullOrEmpty(_commandLine.VirtualMachineId))
-            {
-                // If user doesn't specify a virtual machine identifier, we default to null (not empty string)
-                return Errorable.Success<string>(null);
-            }
-
-            return Errorable.Success(_commandLine.VirtualMachineId);
+            // VirtualMachineId is not allowed to be set to null, but string.Empty is valid
+            // (that's the value if otherwise unspecified).
+            return Errorable.Success(_commandLine.VirtualMachineId ?? string.Empty);
         }
 
         private Errorable<DateTimeOffset> NotBefore()

--- a/src/sestest/ServerCommandLine.cs
+++ b/src/sestest/ServerCommandLine.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
     [Verb("server", HelpText = "Run as a standalone software entitlement server.")]
     public sealed class ServerCommandLine : CommandLineBase
     {
+        public const string DefaultServerUrl = "https://localhost:4443";
+
         [Option("sign", HelpText = "Thumbprint of the certificate used to sign tokens (optional; if specified, all tokens must be signed).")]
         public string SigningCertificateThumbprint { get; set; }
 
@@ -17,8 +19,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("connection", HelpText = "Thumbprint of the certificate to pin for use with HTTPS (mandatory).")]
         public string ConnectionCertificateThumbprint { get; set; }
 
-        [Option("url", HelpText = "The URL at which the server should process requests (defaults to 'https://localhost:4443'; must start with 'https:').")]
-        public string ServerUrl { get; set; } = "https://localhost:4443";
+        [Option("url", HelpText = "The URL at which the server should process requests (defaults to '" + DefaultServerUrl + "'; must start with 'https:').")]
+        public string ServerUrl { get; set; }
 
         [Option("audience", HelpText = "[Internal] Audience to which all tokens must be addressed (optional).")]
         public string Audience { get; set; }

--- a/src/sestest/ServerOptionBuilder.cs
+++ b/src/sestest/ServerOptionBuilder.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         {
             var result = Errorable.Success(new ServerOptions())
                 .Configure(ServerUrl(), (opt, url) => opt.WithServerUrl(url))
-                .ConfigureOptional(ConnectionCertificate(), (opt, cert) => opt.WithConnectionCertificate(cert))
-                .ConfigureOptional(SigningCertificate(), (opt, cert) => opt.WithSigningCertificate(cert))
-                .ConfigureOptional(EncryptingCertificate(), (opt, cert) => opt.WithEncryptionCertificate(cert))
-                .ConfigureOptional(Audience(), (opt, audience) => opt.WithAudience(audience))
-                .ConfigureOptional(Issuer(), (opt, issuer) => opt.WithIssuer(issuer))
-                .ConfigureSwitch(ExitAfterRequest(), opt => opt.WithAutomaticExitAfterOneRequest());
+                .Configure(ConnectionCertificate(), (opt, cert) => opt.WithConnectionCertificate(cert))
+                .Configure(SigningCertificate(), (opt, cert) => opt.WithSigningCertificate(cert))
+                .Configure(EncryptingCertificate(), (opt, cert) => opt.WithEncryptionCertificate(cert))
+                .Configure(Audience(), (opt, audience) => opt.WithAudience(audience))
+                .Configure(Issuer(), (opt, issuer) => opt.WithIssuer(issuer))
+                .Configure(ExitAfterRequest(), (opt, exit) => opt.WithAutomaticExitAfterOneRequest(exit));
 
             return result;
         }
@@ -56,14 +56,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// relevant errors.</returns>
         private Errorable<Uri> ServerUrl()
         {
-            if (string.IsNullOrWhiteSpace(_commandLine.ServerUrl))
-            {
-                return Errorable.Failure<Uri>("No server endpoint URL specified.");
-            }
+            // If the server URL is not specified, default it.
+            var serverUrl = string.IsNullOrWhiteSpace(_commandLine.ServerUrl)
+                ? ServerCommandLine.DefaultServerUrl
+                : _commandLine.ServerUrl;
 
             try
             {
-                var result = new Uri(_commandLine.ServerUrl);
+                var result = new Uri(serverUrl);
                 if (!result.HasScheme("https"))
                 {
                     return Errorable.Failure<Uri>("Server endpoint URL must specify https://");

--- a/src/sestest/ServerOptions.cs
+++ b/src/sestest/ServerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
 {
@@ -55,31 +56,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <summary>
         /// Create a modified <see cref="ServerOptions"/> with the specified signing certificate
         /// </summary>
-        /// <param name="certificate">Signing certificate to use (may not be null).</param>
+        /// <param name="certificate">Signing certificate to use (may be null).</param>
         /// <returns>New instance of <see cref="ServerOptions"/>.</returns>
         public ServerOptions WithSigningCertificate(X509Certificate2 certificate)
         {
-            if (certificate == null)
-            {
-                throw new ArgumentNullException(nameof(certificate));
-            }
-
-            return new ServerOptions(this, signingCertificate: certificate);
+            return new ServerOptions(this, signingCertificate: Specify.As(certificate));
         }
 
         /// <summary>
         /// Create a modified <see cref="ServerOptions"/> with the specified encryption certificate
         /// </summary>
-        /// <param name="certificate">Signing certificate to use (may not be null).</param>
+        /// <param name="certificate">Encryption certificate to use (may be null).</param>
         /// <returns>New instance of <see cref="ServerOptions"/>.</returns>
         public ServerOptions WithEncryptionCertificate(X509Certificate2 certificate)
         {
-            if (certificate == null)
-            {
-                throw new ArgumentNullException(nameof(certificate));
-            }
-
-            return new ServerOptions(this, encryptionCertificate: certificate);
+            return new ServerOptions(this, encryptionCertificate: Specify.As(certificate));
         }
 
         /// <summary>
@@ -94,7 +85,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentNullException(nameof(certificate));
             }
 
-            return new ServerOptions(this, connectionCertificate: certificate);
+            return new ServerOptions(this, connectionCertificate: Specify.As(certificate));
         }
 
         /// <summary>
@@ -109,7 +100,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentNullException(nameof(url));
             }
 
-            return new ServerOptions(this, serverUrl: url);
+            return new ServerOptions(this, serverUrl: Specify.As(url));
         }
 
         /// <summary> 
@@ -124,7 +115,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentException("Expect to have an audience", nameof(audience));
             }
 
-            return new ServerOptions(this, audience: audience);
+            return new ServerOptions(this, audience: Specify.As(audience));
         }
 
         /// <summary> 
@@ -139,16 +130,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 throw new ArgumentException("Expect to have an issuer", nameof(issuer));
             }
 
-            return new ServerOptions(this, issuer: issuer);
+            return new ServerOptions(this, issuer: Specify.As(issuer));
         }
 
         /// <summary>
         /// Indicate whether the server should automatically shut down after processing one request
         /// </summary>
         /// <returns>New instance of <see cref="ServerOptions"/>.</returns>
-        public ServerOptions WithAutomaticExitAfterOneRequest()
+        public ServerOptions WithAutomaticExitAfterOneRequest(bool exitAfterRequest)
         {
-            return new ServerOptions(this, exitAfterRequest: true);
+            return new ServerOptions(this, exitAfterRequest: Specify.As(exitAfterRequest));
         }
 
         /// <summary>
@@ -164,26 +155,26 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <param name="exitAfterRequest">Specify whether to automatically shut down after one request.</param>
         private ServerOptions(
             ServerOptions original,
-            X509Certificate2 signingCertificate = null,
-            X509Certificate2 encryptionCertificate = null,
-            X509Certificate2 connectionCertificate = null,
-            Uri serverUrl = null,
-            string audience = null,
-            string issuer = null,
-            bool? exitAfterRequest = null)
+            Specifiable<X509Certificate2> signingCertificate = default,
+            Specifiable<X509Certificate2> encryptionCertificate = default,
+            Specifiable<X509Certificate2> connectionCertificate = default,
+            Specifiable<Uri> serverUrl = default,
+            Specifiable<string> audience = default,
+            Specifiable<string> issuer = default,
+            Specifiable<bool> exitAfterRequest = default)
         {
             if (original == null)
             {
                 throw new ArgumentNullException(nameof(original));
             }
 
-            SigningCertificate = signingCertificate ?? original.SigningCertificate;
-            EncryptionCertificate = encryptionCertificate ?? original.EncryptionCertificate;
-            ConnectionCertificate = connectionCertificate ?? original.ConnectionCertificate;
-            ServerUrl = serverUrl ?? original.ServerUrl;
-            Audience = audience ?? original.Audience;
-            Issuer = issuer ?? original.Issuer;
-            ExitAfterRequest = exitAfterRequest ?? original.ExitAfterRequest;
+            SigningCertificate = signingCertificate.OrDefault(original.SigningCertificate);
+            EncryptionCertificate = encryptionCertificate.OrDefault(original.EncryptionCertificate);
+            ConnectionCertificate = connectionCertificate.OrDefault(original.ConnectionCertificate);
+            ServerUrl = serverUrl.OrDefault(original.ServerUrl);
+            Audience = audience.OrDefault(original.Audience);
+            Issuer = issuer.OrDefault(original.Issuer);
+            ExitAfterRequest = exitAfterRequest.OrDefault(original.ExitAfterRequest);
         }
     }
 }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             ConnectionCertificateThumbprint = ConnectionCertificateThumbprint.ToString()
         };
 
-        // Permissive options to bypass mandatory errors when testing other properties
         private const string CertificateNotFoundError = "Certificate not found test error";
 
         private readonly ICertificateStore _certificateStore = new FakeCertificateStore(
@@ -31,19 +30,11 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         public class ServerUrl : ServerOptionBuilderTests
         {
             [Fact]
-            public void Build_WithEmptyServerUrl_DoesNotReturnValue()
+            public void Build_WithEmptyServerUrl_SetsDefaultServerUrl()
             {
                 _commandLine.ServerUrl = string.Empty;
                 var options = new ServerOptionBuilder(_commandLine, _certificateStore).Build();
-                options.HasValue.Should().BeFalse();
-            }
-
-            [Fact]
-            public void Build_WithEmptyServerUrl_HasErrorForServerUrl()
-            {
-                _commandLine.ServerUrl = string.Empty;
-                var options = new ServerOptionBuilder(_commandLine, _certificateStore).Build();
-                options.Errors.Should().Contain(e => e.Contains("server endpoint URL"));
+                options.Value.ServerUrl.Should().Be(ServerCommandLine.DefaultServerUrl);
             }
 
             [Fact]


### PR DESCRIPTION
Updated `*Builder` classes to use `Specifiable` instead of null checking, allowing builder methods to be called always rather than conditionally, making two `ErrorableExtensions.Configure*` methods redundant.