### PR TITLE
Implement equality for Specifiable

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 {
     /// <summary>
@@ -8,14 +10,14 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
     /// a value may be specified as null.
     /// </remarks>
     /// <typeparam name="T">The type of the value to be specified.</typeparam>
-    public struct Specifiable<T>
+    public struct Specifiable<T> : IEquatable<Specifiable<T>>
     {
         /// <summary>
         /// Whether the value is specified.
         /// </summary>
         public bool IsSpecified { get; }
 
-        private T _value;
+        private readonly T _value;
 
         /// <summary>
         /// Initializes a new instance of a specifiable value interpreted as
@@ -41,5 +43,39 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <paramref name="other"/> value.
         /// </returns>
         public T OrDefault(T other) => IsSpecified ? _value : other;
+
+        /// <summary>
+        /// Test to see if another <see cref="Specifiable{T}"/> is equal to this instance
+        /// </summary>
+        /// <param name="other">Other specifiable for comparison.</param>
+        /// <returns>True if both contain the same value, false otherwise.</returns>
+        public bool Equals(Specifiable<T> other)
+            => ReferenceEquals(_value, other._value)
+               || (_value?.Equals(other._value) ?? false);
+
+        /// <summary>
+        /// Test to see if another object is equal to this instance
+        /// </summary>
+        /// <param name="obj">Other object for comparison.</param>
+        /// <returns>True if both contain the same value, false otherwise.</returns>
+        public override bool Equals(object obj)
+            => obj is Specifiable<T> s && Equals(s);
+
+        /// <summary>
+        /// Generate a hash code based on our contained value
+        /// </summary>
+        /// <returns>Hash code based on <see cref="_value"/> or 0 if we hold a null.</returns>
+        public override int GetHashCode()
+            => _value?.GetHashCode() ?? 0;
+
+        public static bool operator ==(Specifiable<T> left, Specifiable<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Specifiable<T> left, Specifiable<T> right)
+        {
+            return !left.Equals(right);
+        }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Specifiable.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <param name="other">Other specifiable for comparison.</param>
         /// <returns>True if both contain the same value, false otherwise.</returns>
         public bool Equals(Specifiable<T> other)
-            => ReferenceEquals(_value, other._value)
-               || (_value?.Equals(other._value) ?? false);
+            => IsSpecified == other.IsSpecified
+               && Equals(_value, other._value);
 
         /// <summary>
         /// Test to see if another object is equal to this instance

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
@@ -118,6 +118,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
 
             private readonly Specifiable<string> _null = Specify.As<string>(null);
 
+            private readonly Specifiable<string> _unspecified = new Specifiable<string>();
+
             [Fact]
             public void GivenSelf_ReturnsTrue()
             {
@@ -128,6 +130,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             public void GivenOther_ReturnsFalse()
             {
                 _sample.Equals(_other).Should().BeFalse();
+            }
+
+            [Fact]
+            public void GivenUnspecified_ReturnsFalse()
+            {
+                _sample.Equals(_unspecified).Should().BeFalse();
             }
 
             [Fact]
@@ -146,6 +154,30 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
             public void ContainingNullGivenOther_ReturnsFalse()
             {
                 _null.Equals(_other).Should().BeFalse();
+            }
+
+            [Fact]
+            public void ContainingNullGivenUnspecified_ReturnsFalse()
+            {
+                _null.Equals(_unspecified).Should().BeFalse();
+            }
+
+            [Fact]
+            public void WhenUnspecified_EqualsSelf()
+            {
+                _unspecified.Equals(_unspecified).Should().BeTrue();
+            }
+
+            [Fact]
+            public void WhenUnspecified_DoesNotEqualOther()
+            {
+                _unspecified.Equals(_other).Should().BeFalse();
+            }
+
+            [Fact]
+            public void WhenUnspecified_DoesNotEqualNull()
+            {
+                _unspecified.Equals(_null).Should().BeFalse();
             }
         }
     }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/SpecifiableTests.cs
@@ -84,5 +84,69 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests
                 result.Should().Be(_otherStringValue);
             }
         }
+
+        public class EqualsObject : SpecifiableTests
+        {
+            private readonly Specifiable<string> _sample = Specify.As("sample");
+
+            private readonly Specifiable<string> _other = Specify.As("other");
+
+            [Fact]
+            public void GivenSelf_ReturnsTrue()
+            {
+                _sample.Equals((object) _sample).Should().BeTrue();
+            }
+
+            [Fact]
+            public void GivenOther_ReturnsFalse()
+            {
+                _sample.Equals((object)_other).Should().BeFalse();
+            }
+
+            [Fact]
+            public void GivenNull_ReturnsFalse()
+            {
+                _sample.Equals(null).Should().BeFalse();
+            }
+        }
+
+        public class EqualsSpecifiable : SpecifiableTests
+        {
+            private readonly Specifiable<string> _sample = Specify.As("sample");
+
+            private readonly Specifiable<string> _other = Specify.As("other");
+
+            private readonly Specifiable<string> _null = Specify.As<string>(null);
+
+            [Fact]
+            public void GivenSelf_ReturnsTrue()
+            {
+                _sample.Equals(_sample).Should().BeTrue();
+            }
+
+            [Fact]
+            public void GivenOther_ReturnsFalse()
+            {
+                _sample.Equals(_other).Should().BeFalse();
+            }
+
+            [Fact]
+            public void GivenNull_ReturnsFalse()
+            {
+                _sample.Equals(null).Should().BeFalse();
+            }
+
+            [Fact]
+            public void ContainingNullGivenSelf_ReturnsTrue()
+            {
+                _null.Equals(_null).Should().BeTrue();
+            }
+
+            [Fact]
+            public void ContainingNullGivenOther_ReturnsFalse()
+            {
+                _null.Equals(_other).Should().BeFalse();
+            }
+        }
     }
 }


### PR DESCRIPTION
A code analysis update (coming in future PR) is flagging `Specifable<T>` as in need of equality; breaking it out into a separate PR for easy review.