### PR TITLE
Modify convenience scripts to search for exe

### DIFF
--- a/sesclient.ps1
+++ b/sesclient.ps1
@@ -10,7 +10,7 @@ $sesclient = get-childitem $PSScriptRoot\x64\sesclient.native.exe -recurse | sor
 if ($sesclient -eq $null) 
 {
     Write-Host "Could not find 'sesclient.native.exe' within $PSScriptRoot\x64" -ForegroundColor Red
-    Write-Host "Do you need to run a build?" -ForegroundColor Blue
+    Write-Host "Do you need to run a build?" -ForegroundColor Yellow
     exit -1
 }
 

--- a/sesclient.ps1
+++ b/sesclient.ps1
@@ -2,7 +2,17 @@
 # Convenience Launcher for sesclient
 #
 
-$sesclient = "$PSScriptRoot\x64\Debug\sesclient.native.exe"
+# Find the latest version of sesclient.native.exe that was compiled
+# [This will automatically find the right version, even if someone does a release 
+# build or if the output path changes]
+$sesclient = get-childitem $PSScriptRoot\x64\sesclient.native.exe -recurse | sort-object LastWriteTimeUtc | select-object -last 1
+
+if ($sesclient -eq $null) 
+{
+    Write-Host "Could not find 'sesclient.native.exe' within $PSScriptRoot\x64" -ForegroundColor Red
+    Write-Host "Do you need to run a build?" -ForegroundColor Blue
+    exit -1
+}
 
 # Uncomment this line to show which command is being run
 # Write-Output "Launching $sesclient $args"

--- a/sestest.ps1
+++ b/sestest.ps1
@@ -7,10 +7,10 @@
 # build or if the output path changes e.g. becuase it's no longer netcoreapp2.0]
 $sestest = get-childitem $PSScriptRoot\out\sestest.dll -recurse | sort-object LastWriteTimeUtc | select-object -last 1
 
-if ($sesclient -eq $null) 
+if ($sestest -eq $null) 
 {
-    Write-Host "Could not find 'sestest.dll' within $PSScriptRoot\x64" -ForegroundColor Red
-    Write-Host "Do you need to run a build?" -ForegroundColor Blue
+    Write-Host "Could not find 'sestest.dll' within $PSScriptRoot\out" -ForegroundColor Red
+    Write-Host "Do you need to run a build?" -ForegroundColor Yellow
     exit -1
 }
 

--- a/sestest.ps1
+++ b/sestest.ps1
@@ -2,7 +2,18 @@
 # Convenience Launcher for sestest
 #
 
-$sestest = "$PSScriptRoot\out\sestest\netcoreapp2.0\sestest.dll"
+# Find the latest version of sestest that was compiled
+# [This will automatically find the right version, even if someone does a release 
+# build or if the output path changes e.g. becuase it's no longer netcoreapp2.0]
+$sestest = get-childitem $PSScriptRoot\out\sestest.dll -recurse | sort-object LastWriteTimeUtc | select-object -last 1
+
+if ($sesclient -eq $null) 
+{
+    Write-Host "Could not find 'sestest.dll' within $PSScriptRoot\x64" -ForegroundColor Red
+    Write-Host "Do you need to run a build?" -ForegroundColor Blue
+    exit -1
+}
+
 
 # Uncomment this line to show which exe is being run
 # Write-Output "Launching $sestest"


### PR DESCRIPTION
Remove hardcoded output paths used for `sestest` and `sesclient` and instead search for the most recently compiled exe.

Makes things robust in the face of changes to the output directories, as well as accommodating users who choose to compile *Release* builds instead.