### PR TITLE
Alter 'address' format in token generation command

### DIFF
--- a/src/sestest/GenerateCommandLine.cs
+++ b/src/sestest/GenerateCommandLine.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         [Option("not-after", HelpText = "The moment at which the token expires and the application is no longer entitled to execute (format 'yyyy-mm-ddThh:mm'; 24 hour clock; local time; defaults to 7 days).")]
         public string NotAfter { get; set; }
 
-        [Option("address", HelpText = "The externally visible IP addresses of the machine entitled to execute the application(s) (defaults to the addresses of the current machine).")]
+        [Option("address", HelpText = "The externally visible IP addresses of the machine entitled to execute the application(s) (comma separated, defaults to the addresses of the current machine).", Separator = ',')]
         public IList<string> Addresses { get; set; } = new List<string>();
 
         [Option("sign", HelpText = "Certificate thumbprint of the certificate used to sign the token.")]


### PR DESCRIPTION
In `sestest generate`, application IDs are specified using comma-separation, but IP addresses use spaces. Altered the IP address format for consistency.