### PR TITLE
Restrict the search for sestest.dll to within the out/sestest directory

### DIFF
--- a/sestest.ps1
+++ b/sestest.ps1
@@ -5,7 +5,7 @@
 # Find the latest version of sestest that was compiled
 # [This will automatically find the right version, even if someone does a release 
 # build or if the output path changes e.g. becuase it's no longer netcoreapp2.0]
-$sestest = get-childitem $PSScriptRoot\out\sestest.dll -recurse | sort-object LastWriteTimeUtc | select-object -last 1
+$sestest = get-childitem $PSScriptRoot\out\sestest\sestest.dll -recurse | sort-object LastWriteTimeUtc | select-object -last 1
 
 if ($sestest -eq $null) 
 {


### PR DESCRIPTION
This fixes the defect:
`A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'D:\github\azure-batch-software-entitlement\out\Microsoft.Azure.Batch.SoftwareEntitlement.Tests\netcoreapp2.0\'.`
The new automatic assembly location functionality was finding `sestest.dll` in the `Tests` directory rather than `sestest`.
Both the build scripts and Visual Studio place the build output under `out\sestest` so I think this restriction is safe.