### PR TITLE
Fix defect caused by the dotnet CLI first-use welcome prompt

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -49,6 +49,9 @@ function TryLoad-Psake-ViaNuGetCache()
     }
 }
 
+# Prevent the dotnet CLI from displaying a welcome message on first use
+$env:DOTNET_PRINT_TELEMETRY_MESSAGE = "false"
+
 # Try to load a local copy first (so we can ensure a particular version is used)
 TryLoad-Psake .\lib\psake
 


### PR DESCRIPTION
When running `dotnet nuget locals all --list` for the first time, the tool by default displays a welcome message about telemetry. This causes errors when parsing the output to determine nuget cache locations. The fix here is to disable the message by setting the `DOTNET_PRINT_TELEMETRY_MESSAGE` environment variable to `"false"`.