### PR TITLE
Return an error code in sestest verify if verification fails

### DIFF
--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -43,11 +43,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Errorable<string> app = FindApplication(commandLine);
             Errorable<string> api = FindApiVersion(commandLine);
 
-            var result = await server.With(token)
+            Errorable<int> result = await server.With(token)
                 .With(app)
                 .With(api)
                 .MapAsync(SubmitToken)
                 .ConfigureAwait(false);
+
             return result.Match(
                 exitCode => exitCode,
                 errors =>

--- a/src/sestest/VerifyCommand.cs
+++ b/src/sestest/VerifyCommand.cs
@@ -43,16 +43,13 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             Errorable<string> app = FindApplication(commandLine);
             Errorable<string> api = FindApiVersion(commandLine);
 
-            Errorable<string> result = await server.With(token)
+            var result = await server.With(token)
                 .With(app)
                 .With(api)
                 .MapAsync(SubmitToken)
                 .ConfigureAwait(false);
-            return result.Match(response =>
-                {
-                    Logger.LogJson(response);
-                    return ResultCodes.Success;
-                },
+            return result.Match(
+                exitCode => exitCode,
                 errors =>
                 {
                     Logger.LogErrors(errors);
@@ -60,7 +57,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 });
         }
 
-        private async Task<string> SubmitToken(Uri server, string token, string app, string api)
+        private async Task<int> SubmitToken(Uri server, string token, string app, string api)
         {
             var serverPath = server.AbsolutePath.EndsWith('/')
                 ? server.AbsolutePath
@@ -92,9 +89,18 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                     content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json; odata=minimalmetadata");
 
                     var result = await client.PostAsync(uri, content).ConfigureAwait(false);
+
                     Logger.LogInformation($"Status Code: {result.StatusCode} ({(int)result.StatusCode})");
 
-                    return await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var responseContent = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    if (!result.IsSuccessStatusCode)
+                    {
+                        Logger.LogError(result.ReasonPhrase);
+                        return ResultCodes.Failed;
+                    }
+
+                    Logger.LogJson(responseContent);
+                    return ResultCodes.Success;
                 }
             }
         }


### PR DESCRIPTION
Need to return a non-zero error code if `sestest verify` results in an entitlement grant. At the moment the entire response is being logged (as information) whether it's successful or not, and the process always returns 0.