### PR TITLE
Update documentation to highlight the need to handle an optional trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Batch service provides two pieces of information to a metered software appli
 
 | Variable                              | Definition                                                                                                        |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `AZ_BATCH_ACCOUNT_URL`                | The URL of an endpoint for the batch service account. <br/> Sample: `https://demo.westus.batch.azure.com` |
+| `AZ_BATCH_ACCOUNT_URL`                | The URL of an endpoint for the batch service account. <br/> Sample: `https://demo.westus.batch.azure.com`         |
 | `AZ_BATCH_SOFTWARE_ENTITLEMENT_TOKEN` | An encoded string containing the actual software entitlement token.                                               |
 
 The software package will check that the provided batch account endpoint specifies a *known host* (such as `*.batch.azure.com` or one of the equivalents for national clouds); if it does not, the software package should not consider itself entitled. If the endpoint is known, the software application will request a software entitlement from the specified server over a secured HTTPS/TLS connection.

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -16,10 +16,10 @@ Verifies that a provided software entitlement token grants permission to use a s
 
 Sample: `https://samples.westus.batch.azure.com/softwareEntitlements/?api-version=2017-99-99-9.9`
 
-| Placeholder | Type   | Description                                                                                                                                                                                                                                                                      |
-| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via environment variable.                                                                                                                                                                                                 |
-| version     | string | The API version of the request. <br/> Specify version `2017-99-99.9.9` or higher. <br/> For older API versions, see the end of this document. <br/> All Batch API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning |
+| Placeholder | Type   | Description                                                                                                                                                                                                                                                                                                          |
+|-------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| endpoint    | string | The Batch account URL endpoint supplied by Azure Batch via the environment variable `AZ_BATCH_ACCOUNT_URL`.<br/>This may have a trailing `/` (e.g. `https://demo.westus.batch.azure.com/`) or it might not (e.g. `https://demo.westus.batch.azure.com`); clients should be prepared to handle either case correctly. |
+| version     | string | The API version of the request. <br/> Specify version `2017-99-99.9.9` or higher. <br/> For older API versions, see the end of this document. <br/> All Batch API versions are listed @ https://docs.microsoft.com/en-us/rest/api/batchservice/batch-service-rest-api-versioning                                     |
 
 The following shows a sample JSON payload for the request:
 
@@ -92,6 +92,14 @@ The service will return HTTP status 400 and the response body will be empty if:
 * The software entitlement token is missing, invalid, corrupt, or missing any mandatory fields;
 * The request is badly formed; or
 * The `api-version` specified on the URL is invalid.
+
+### RESPONSE 404 - NOT FOUND
+
+The service will return HTTP status 404 if the URL is malformed. 
+
+The most common cause for this is code that always adds a separating `/` to the end of the URL provided in `AZ_BATCH_ACCOUNT_URL` without checking to see if a trailing `/` is already present.
+
+E.g. if `AZ_BATCH_ACCOUNT_URL` is set to `https://demo.westus.batch.azure.com/` and the client appends `/softwareEntitlements/?api-version=2017-99-99-9.9` then the resulting URL of `https://demo.westus.batch.azure.com//softwareEntitlements/?api-version=2017-99-99-9.9` (containing a double `//`) will be invalid.
 
 ## Historical Versions
 


### PR DESCRIPTION
The trailing slash on `AZ_BATCH_ACCOUNT_URL` might or might not be there - and client code needs to handle both cases.