### PR TITLE
Revert "Update documentation for API v2 (#77)"

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -66,27 +66,20 @@ if ((get-module psake) -eq $null) {
 }
 
 if ((get-module psake) -eq $null) {
-    # Still not loaded, let's try the various NuGet caches
-    $locals = .\nuget locals all -list
-    foreach($local in $locals)
-    {
-        $index = $local.IndexOf(":")
-        $folder = $local.Substring($index + 2)
-        TryLoad-Psake $folder
-    }
-    
-if ((get-module psake) -eq $null) {
     # Not yet loaded, try to load it from the chocolatey installation library
     TryLoad-Psake $env:ProgramData\chocolatey\lib
 }
 
-$psake = get-module psake
-if ($psake -ne $null) {
-    $psakePath = $psake.Path
-    Write-Output "[+] Psake loaded from $psakePath"
+if ((get-module psake) -eq $null) {
+    # Still not loaded, let's look in the various NuGet caches
+    TryLoad-Psake-ViaNuGetCache
 }
-else {
-    throw "Unable to load psake"
+
+if ((get-module psake) -eq $null) {
+    # STILL not loaded, let's try to install it via dotnet, then probe again
+    Write-Output "[!] Running 'dotnet restore' to download psake"
+    dotnet restore .\src\sestest\sestest.csproj --verbosity minimal
+    TryLoad-Psake-ViaNuGetCache
 }
 
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/readme.md
@@ -30,17 +30,12 @@ The following shows a sample JSON payload for the request:
 }
 ```
 
-| Element       | Required  | Type    | Description                                                                                                                                                                                                                                                              |
-| ------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| token         | Mandatory | string  | The software entitlement token supplied to the software package via environment variable from Azure Batch                                                                                                                                                                |
-| applicationId | Mandatory | string  | A unique identifier for the application requesting an entitlement to run. <br/> **Samples**: contosoapp, application <br/> Application identifiers are lowercase (though comparisons will be case-insensitive), with no punctuation, whitespace or non-alpha characters. |
-| hostid        | Mandatory | string  | A unique identifier for the current host (the machine requesting entitlement).                                                                                                                                                                                           |
-| cores         | Mandatory | integer | The number of processor cores detected on the host machine                                                                                                                                                                                                               |
+| Element       | Required  | Type   | Description                                                                                                                                                                                                                                                                                |
+| ------------- | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| token         | Mandatory | string | The software entitlement token supplied to the software package via environment variable from Azure Batch                                                                                                                                                                                  |
+| applicationId | Mandatory | string | A unique identifier for the application requesting an entitlement to run. <br/> **Samples**: contosoapp, application <br/> Application identifiers are lowercase (though comparisons will be case-insensitive), with no punctuation, whitespace or non-alpha characters. |
 
 Specific unique application identifiers for each software package will be agreed between Azure Batch and the software vendor in advance, prior to integration.
-
-The `hostid` is used to lock an entitlement for use by a specific machine, mitigating against any reuse attack that tries to exfiltrate tokens to other machines for use. The exact details used to create a machine hash are specific to each application - it just needs to be a printable string.
-We recommend using information that is unlikely to change between machine reboots, such as IP addresses and hard drive labels. Using transient informaiton that changes (such as the current time, a nonce value, or the current process id) is discouraged because it would inappropriately prevent multiple invocations of properly licensed applications from occuring at the same time under the same entitlement token.
 
 ### RESPONSE 200 - OK
 


### PR DESCRIPTION
This reverts commit e7b3b22782caab756d7efe2d15ae5004233a6ded.

Aside from documentation enhancements, which have been retained, this reverts the updates to the bootstrap script and hostid-related additions to the server project readme.