### PR TITLE
Fix git command for retrieving short commit identifier

### DIFF
--- a/scripts/psake-build.ps1
+++ b/scripts/psake-build.ps1
@@ -75,7 +75,7 @@ Task Generate.Version {
     $branch = git name-rev --name-only HEAD
     Write-Output "Branch   $branch"
 
-    $commit = git rev-parse --short head
+    $commit = git rev-parse --short HEAD
     Write-Output "Commit   $commit"
 
     $script:version = "$versionBase.$patchVersion"


### PR DESCRIPTION
This was the only thing that needed changing to get the `psake` build working on Linux