### PR TITLE
Fix compiler errors for non-windows platform

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <mutex>
+#include <thread>
+#include <chrono>
 #include <sstream>
 #include <vector>
 #include <cstdlib>
@@ -638,7 +640,6 @@ struct WinHttpDeleter
 };
 
 typedef std::unique_ptr<void, WinHttpDeleter> WinHttpHandle;
-#endif
 
 //
 // OpenSSL does not hook into the Windows Automatic Root Certificates Update process.
@@ -705,6 +706,7 @@ void EnsureRootCertsArePopulated(const std::string& url)
         0)
     );
 }
+#endif
 
 }   // anonymous namespace
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Client.Native/SoftwareEntitlementClient.cpp
@@ -628,6 +628,7 @@ public:
     }
 };
 
+#ifdef _WIN32
 struct WinHttpDeleter
 {
     void operator()(HINTERNET h)
@@ -637,6 +638,7 @@ struct WinHttpDeleter
 };
 
 typedef std::unique_ptr<void, WinHttpDeleter> WinHttpHandle;
+#endif
 
 //
 // OpenSSL does not hook into the Windows Automatic Root Certificates Update process.
@@ -801,7 +803,7 @@ std::unique_ptr<Entitlement> GetEntitlement(
             {
                 std::this_thread::sleep_for(std::chrono::seconds(retry));
             }
-#ifdef WIN32
+#ifdef _WIN32
             else if (e.GetCode() == CURLE_SSL_CACERT)
             {
                 EnsureRootCertsArePopulated(url);


### PR DESCRIPTION
- Wrap WinHttpDeleter structure with _WIN32 macro.
- Use _WIN32 instead of WIN32