### PR TITLE
upgrade to .net core 2.2

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -6,19 +6,25 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.5" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -11,8 +11,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/Microsoft.Azure.Batch.SoftwareEntitlement.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -22,15 +22,21 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -32,8 +32,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Server/Microsoft.Azure.Batch.SoftwareEntitlement.Server.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup Label="Configuration">
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
@@ -23,13 +23,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
   </ItemGroup>

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtPropertyParser.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtPropertyParser.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 return Failure(UnexpectedAudienceError(exception.InvalidAudience));
             }
             catch (ArgumentException exception)
-                when (exception.Message.StartsWith("IDX", StringComparison.InvariantCulture))
+                when (exception.Message.StartsWith("IDX", StringComparison.Ordinal))
             {
                 // This covers a number of cases, including:
                 //  - Unexpected number of parts (base-64 strings separated by period characters)

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtPropertyParser.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/JwtPropertyParser.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 RequireSignedTokens = _signingKey != null,
                 ClockSkew = TimeSpan.FromSeconds(60),
                 IssuerSigningKey = _signingKey,
-                ValidateIssuerSigningKey = true,
+                ValidateIssuerSigningKey = _signingKey != null,
                 TokenDecryptionKey = _encryptionKey
             };
 
@@ -106,6 +106,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             catch (SecurityTokenInvalidAudienceException exception)
             {
                 return Failure(UnexpectedAudienceError(exception.InvalidAudience));
+            }
+            catch (ArgumentException exception)
+                when (exception.Message.StartsWith("IDX", StringComparison.InvariantCulture))
+            {
+                // This covers a number of cases, including:
+                //  - Unexpected number of parts (base-64 strings separated by period characters)
+                //  - Invalid characters (not base-64)
+                //  - Invalid base-64 strings (not decodable)
+                //  - base-64 strings that decode to invalid JWT parts
+                return Failure("Token is not well formed");
             }
             catch (Exception exception)
             {

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -6,14 +6,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="psake" Version="4.7.0" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="psake" Version="4.7.4" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="psake" Version="4.7.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement/Microsoft.Azure.Batch.SoftwareEntitlement.csproj
@@ -11,9 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="psake" Version="4.7.4" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Microsoft.Azure.Batch.SoftwareEntitlement</RootNamespace>
     <AssemblyName>sestest</AssemblyName>
   </PropertyGroup>
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="psake" Version="4.7.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -8,21 +8,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="psake" Version="4.7.0" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="psake" Version="4.7.4" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/sestest/sestest.csproj
+++ b/src/sestest/sestest.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="psake" Version="4.7.4" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,10 +9,10 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -5,22 +5,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>
@@ -15,11 +15,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="ReportGenerator" Version="4.0.5" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/TimestampParserTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests/TimestampParserTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common.Tests

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/JwtPropertyParserTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/JwtPropertyParserTests.cs
@@ -51,11 +51,71 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
         public class MalformedToken : JwtPropertyParserTests
         {
             [Fact]
-            public void WhenTokenMalformed_ReturnsError()
+            public void WhenTokenContainsOnlyOnePart_ReturnsError()
             {
                 var tokenProperties = _sourceTokenProperties;
                 var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
-                var result = parser.Parse("notarealtoken");
+                var result = parser.Parse("nodots");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenContainsTooManyParts_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse("e30=.e30=.e30=.e30=");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenContainsInvalidCharacters_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse("🤘.🤙.🤚");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenContainsInvalidBase64_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse("a.a.a");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenContainsInvalidContent_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse("bm90.Z29vZA==.YmFzZTY0");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenMissingHeader_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse(".e30=.e30=");
+                result.HasValue.Should().BeFalse();
+                result.Errors.Should().Contain(e => e.Contains("not well formed"));
+            }
+
+            [Fact]
+            public void WhenTokenMissingPayload_ReturnsError()
+            {
+                var tokenProperties = _sourceTokenProperties;
+                var parser = CreateParser(tokenProperties.Audience, tokenProperties.Issuer);
+                var result = parser.Parse("e30=..e30=");
                 result.HasValue.Should().BeFalse();
                 result.Errors.Should().Contain(e => e.Contains("not well formed"));
             }

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -6,18 +6,18 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="ReportGenerator" Version="4.0.5" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests.csproj
@@ -5,19 +5,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/sestest.Tests/sestest.Tests.csproj
+++ b/tests/sestest.Tests/sestest.Tests.csproj
@@ -7,18 +7,18 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+    <PackageReference Include="ReportGenerator" Version="4.0.5" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/sestest.Tests/sestest.Tests.csproj
+++ b/tests/sestest.Tests/sestest.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Microsoft.Azure.Batch.SoftwareEntitlement.Tests</RootNamespace>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />

--- a/tests/sestest.Tests/sestest.Tests.csproj
+++ b/tests/sestest.Tests/sestest.Tests.csproj
@@ -6,20 +6,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" />
-    <PackageReference Include="Roslynator.Analyzers" Version="1.6.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The managed projects all currently target dotnet core 2.0. This retargets them to 2.2, as well as updating nuget dependencies to the latest versions.

This also handles a couple of behaviour changes in the latest `System.IdentityModel.Tokens.Jwt` assembly's `ValidateToken` method: [`ValidateIssuerSigningKey` should not `false` if `RequireSignedTokens` is `false`](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/972), and some of the exception messages have changed.