### PR TITLE
Enhance sestest list-certificates to display certificates appropriate for server authentication

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/X509Certificate2Extensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/X509Certificate2Extensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
     /// </summary>
     public static class X509Certificate2Extensions
     {
+        // See: https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.https.httpsconnectionadapteroptions?view=aspnetcore-2.2#properties
         private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
 
         /// <summary>
@@ -35,12 +36,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <returns>True if the certificate supports server authentication; false otherwise.</returns>
         public static bool SupportsServerAuthentication(this X509Certificate2 certificate)
         {
+            // From the HttpsConnectionAdapterOptions documentation:
+            // "If the server certificate has an Extended Key Usage extension, the usages must include
+            // Server Authentication (OID 1.3.6.1.5.5.7.3.1)"
+            var ekuExtensions = certificate.Extensions.OfType<X509EnhancedKeyUsageExtension>().ToList();
+            if (!ekuExtensions.Any())
+            {
+                return true;
+            }
+
             var oidValues =
-                from extension in certificate.Extensions.OfType<X509EnhancedKeyUsageExtension>()
+                from extension in ekuExtensions
                 from oid in extension.EnhancedKeyUsages.OfType<Oid>()
                 select oid.Value;
 
-            return oidValues.Any(oid => oid.Equals(ServerAuthenticationOid, StringComparison.Ordinal));
+            return oidValues.Any(oid => string.Equals(oid, ServerAuthenticationOid, StringComparison.Ordinal));
         }
     }
 }

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/X509Certificate2Extensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/X509Certificate2Extensions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
@@ -8,6 +10,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
     /// </summary>
     public static class X509Certificate2Extensions
     {
+        private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
         /// <summary>
         /// Test to see if a certificate supports a specific usage
         /// </summary>
@@ -22,6 +26,21 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
             }
 
             return certificate.Extensions.OfType<X509KeyUsageExtension>().FirstOrDefault()?.KeyUsages.HasFlag(use) ?? true;
+        }
+
+        /// <summary>
+        /// Tests whether a certificate supports server authentication.
+        /// </summary>
+        /// <param name="certificate">Certificate to test.</param>
+        /// <returns>True if the certificate supports server authentication; false otherwise.</returns>
+        public static bool SupportsServerAuthentication(this X509Certificate2 certificate)
+        {
+            var oidValues =
+                from extension in certificate.Extensions.OfType<X509EnhancedKeyUsageExtension>()
+                from oid in extension.EnhancedKeyUsages.OfType<Oid>()
+                select oid.Value;
+
+            return oidValues.Any(oid => oid.Equals(ServerAuthenticationOid, StringComparison.Ordinal));
         }
     }
 }

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                     serverAuthCerts.Where(c => c.IsVerified).Select(c => c.Cert));
 
                 LogCertificates(
-                    "Found {0} non-expired certificates with private keys that allow server authentication and are not verified",
+                    "Found {0} non-expired certificates with private keys that allow server authentication and are NOT verified",
                     serverAuthCerts.Where(c => !c.IsVerified).Select(c => c.Cert));
             }
 

--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -96,6 +96,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                                      && !c.SupportsUse(X509KeyUsageFlags.DataEncipherment)));
             }
 
+            if (showCerts == ShowCertificates.All
+                || showCerts == ShowCertificates.ForServerAuth
+                || showCerts == ShowCertificates.NonExpired)
+            {
+                LogCertificates(
+                    "Found {0} non-expired certificates with private keys that allow server authentication",
+                    candidates.Where(c => now < c.NotAfter
+                                     && c.SupportsServerAuthentication()));
+            }
+
             if (showCerts == ShowCertificates.All)
             {
                 LogCertificates(
@@ -171,7 +181,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             }
 
             return ErrorSet.Create(
-                $"Failed to recognize '{show}'; valid choices are: `nonexpired` (default), 'forsigning', 'forencrypting', 'expired', and 'all'.");
+                $"Failed to recognize '{show}'; valid choices are: `nonexpired` (default), 'forsigning', 'forencrypting', 'expired', 'forserverauth', and 'all'.");
         }
 
         [Flags]
@@ -180,8 +190,9 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
             NonExpired = 1,
             ForSigning = 2,
             ForEncrypting = 4,
-            Expired = 8,
-            All = NonExpired | Expired | ForSigning | ForEncrypting
+            ForServerAuth = 8,
+            Expired = 16,
+            All = NonExpired | Expired | ForSigning | ForEncrypting | ForServerAuth
         }
     }
 }

--- a/src/sestest/ListCertificatesCommandLine.cs
+++ b/src/sestest/ListCertificatesCommandLine.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
     [Verb("list-certificates", HelpText = "List all available certificates.")]
     public sealed class ListCertificatesCommandLine : CommandLineBase
     {
-        [Option(HelpText = "Which certificates should be shown? (one of `nonexpired` (default), 'forsigning', 'forencrypting', 'expired', and 'all').")]
+        [Option(HelpText = "Which certificates should be shown? (one of `nonexpired` (default), 'forsigning', 'forencrypting', 'expired', 'forserverauth', and 'all').")]
         public string Show { get; set; }
     }
 }


### PR DESCRIPTION
`sestest` already supports `forsigning` and `forencryption` arguments to `list-certificates`, as well as grouping the output, to easily identify certificates which can be used for signing and encryption.

When running `sestest server` we also require another kind of certificate, i.e. that which can be used for server authentication (to enable clients to communicate via TLS). Identifying certificates which are appropriate for this involves selecting ones which:
- **If** the certificate has an enhanced key usage extension, the usages must include server authentication (OID 1.3.6.1.5.5.7.3.1). Without this the test server will throw an `InvalidOperationException` ("Certificate XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX cannot be used as an SSL server certificate. It has an Extended Key Usage extension but the usages do not include Server Authentication (OID 1.3.6.1.5.5.7.3.1)").
- (optionally) are trusted (and whose certificate chain can be validated).
- have a DNS name which matches the hostname by which requests will be made to the server (probably `localhost`)

This addresses the first two of these by allowing a `forserverauth` argument to `list-certificates`, and displaying two extra sections in the output: one for certificates suitable for server authentication that _can_ be verified, and one for those that can't.