### PR TITLE
Remove duplicates when running sestest list-certificates

### DIFF
--- a/src/sestest/ListCertificatesCommand.cs
+++ b/src/sestest/ListCertificatesCommand.cs
@@ -48,8 +48,12 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
 
             var certificateStore = new CertificateStore();
             var candidates = certificateStore.FindAll()
+                // Need to filter on private key existence before calling Distinct() because
+                // default equality checking does not take private keys into account.
                 .Where(c => c.HasPrivateKey && c.RawData != null)
+                .Distinct()
                 .ToList();
+
             Logger.LogInformation("Found {Count} certificates with private keys", candidates.Count);
 
             if (showCerts == ShowCertificates.All


### PR DESCRIPTION
The output of `sestest list-certificates` currently displays the same certificate multiple times (if it appears in multiple stores/locations).

These changes ensure certificates are only listed once.