### PR TITLE
Reduce default output width when listing certificates

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/StringExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/StringExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
         /// <returns>
         /// A <see cref="Result{TOk,TError}"/> containing the enum value, or a string describing the parse error.
         /// </returns>
-        public static Result<TEnum, string> ParseEnum<TEnum>(this string value) where TEnum : struct
+        public static Result<TEnum, string> ParseEnum<TEnum>(this string value) where TEnum : struct, Enum
         {
             if (Enum.TryParse<TEnum>(value, true, out var result))
             {

--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/StringExtensions.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
@@ -23,6 +24,25 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
                     yield return nextLine;
                 }
             }
+        }
+
+        /// <summary>
+        /// Attempt to parse an Enum value from a string in a case-insensitive manner.
+        /// </summary>
+        /// <typeparam name="TEnum">The type of the enum</typeparam>
+        /// <param name="value">The string value</param>
+        /// <returns>
+        /// A <see cref="Result{TOk,TError}"/> containing the enum value, or a string describing the parse error.
+        /// </returns>
+        public static Result<TEnum, string> ParseEnum<TEnum>(this string value) where TEnum : struct
+        {
+            if (Enum.TryParse<TEnum>(value, true, out var result))
+            {
+                // Successfully parsed the string
+                return result;
+            }
+
+            return $"Failed to parse {value} into {typeof(TEnum).Name}";
         }
     }
 }

--- a/src/sestest/ListCertificatesCommandLine.cs
+++ b/src/sestest/ListCertificatesCommandLine.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CommandLine;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement
@@ -7,5 +8,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
     {
         [Option(HelpText = "Which certificates should be shown? (one of `nonexpired` (default), 'forsigning', 'forencrypting', 'expired', 'forserverauth', and 'all').")]
         public string Show { get; set; }
+
+        [Option("extra-columns", HelpText = "Which extra columns should be shown? (comma separated, one or more of 'subjectname', and 'friendlyname')", Separator = ',')]
+        public IList<string> ExtraColumns { get; set; } = new List<string>();
     }
 }

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -190,14 +190,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
                 return defaultLevel;
             }
 
-            if (Enum.TryParse<LogLevel>(level, true, out var result))
-            {
-                // Successfully parsed the string
-                return result;
-            }
-
-            return ErrorSet.Create(
-                $"Failed to recognize {purpose} log level '{level}'; valid choices are: error, warning, information, and debug.");
+            return purpose.ParseEnum<LogLevel>().OnError(_ => ErrorSet.Create(
+                $"Failed to recognize {purpose} log level '{level}'; valid choices are: error, warning, information, and debug."));
         }
     }
 }


### PR DESCRIPTION
When running `sestest list-certificates`, the friendly name takes up a lot of horizontal space, causing lines to wrap and making the output hard to read.

This change defaults to displaying only the DNS name, but allowing an `extra-columns` argument for specifying that subject and/or friendly names should also be displayed.

This also addresses the point raised in #130 that it should be easy to see certificates by DNS name so that it should be easy to scan for, e.g. localhost.